### PR TITLE
Replace firebase storage with http storage

### DIFF
--- a/.codesandbox/tasks.json
+++ b/.codesandbox/tasks.json
@@ -29,7 +29,7 @@
       "command": "yarn start",
       "runAtStart": true,
       "preview": {
-        "port": 3000
+        "port": 3003
       }
     },
     "test": {

--- a/.env.development
+++ b/.env.development
@@ -5,7 +5,7 @@ VITE_APP_LIBRARY_URL=https://libraries.excalidraw.com
 VITE_APP_LIBRARY_BACKEND=https://us-central1-excalidraw-room-persistence.cloudfunctions.net/libraries
 
 # collaboration WebSocket server (https://github.com/excalidraw/excalidraw-room)
-VITE_APP_WS_SERVER_URL=http://localhost:3002
+VITE_APP_WS_SERVER_URL=http://localhost:80
 
 VITE_APP_PLUS_LP=https://plus.excalidraw.com
 VITE_APP_PLUS_APP=https://app.excalidraw.com
@@ -13,6 +13,8 @@ VITE_APP_PLUS_APP=https://app.excalidraw.com
 VITE_APP_AI_BACKEND=http://localhost:3015
 
 VITE_APP_FIREBASE_CONFIG='{"apiKey":"AIzaSyCMkxA60XIW8KbqMYL7edC4qT5l4qHX2h8","authDomain":"excalidraw-oss-dev.firebaseapp.com","projectId":"excalidraw-oss-dev","storageBucket":"excalidraw-oss-dev.appspot.com","messagingSenderId":"664559512677","appId":"1:664559512677:web:a385181f2928d328a7aa8c"}'
+
+VITE_APP_HTTP_SERVER_URL=http://localhost:8081/api
 
 # put these in your .env.local, or make sure you don't commit!
 # must be lowercase `true` when turned on
@@ -27,7 +29,7 @@ VITE_APP_DISABLE_TRACKING=true
 FAST_REFRESH=false
 
 # The port the run the dev server
-VITE_APP_PORT=3000
+VITE_APP_PORT=3003
 
 #Debug flags
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         - NODE_ENV=development
     container_name: excalidraw
     ports:
-      - "3000:80"
+      - "3003:3003"
     restart: on-failure
     stdin_open: true
     healthcheck:

--- a/excalidraw-app/data/httpStorage.ts
+++ b/excalidraw-app/data/httpStorage.ts
@@ -1,0 +1,217 @@
+import { Socket } from "socket.io-client";
+import { getSyncableElements } from ".";
+import {
+  MIME_TYPES,
+  getSceneVersion,
+  restoreElements,
+} from "../../packages/excalidraw";
+import {
+  BinaryFileData,
+  BinaryFileMetadata,
+  DataURL,
+} from "../../packages/excalidraw/types";
+import {
+  ExcalidrawElement,
+  FileId,
+} from "../../packages/excalidraw/element/types";
+import { decompressData } from "../../packages/excalidraw/data/encode";
+import Portal from "../collab/Portal";
+
+export const encryptElements = async (
+  elements: readonly ExcalidrawElement[],
+): Promise<any> => {
+  return JSON.stringify(elements);
+};
+
+const httpStorageSceneVersionCache = new WeakMap<Socket, number>();
+
+const HTTP_STORAGE_BACKEND_URL = import.meta.env.VITE_APP_HTTP_SERVER_URL;
+
+export const isSavedToHttpStorage = (
+  portal: Portal,
+  elements: readonly ExcalidrawElement[],
+): boolean => {
+  if (portal.socket && portal.roomId && portal.roomKey) {
+    const sceneVersion = getSceneVersion(elements);
+
+    return httpStorageSceneVersionCache.get(portal.socket) === sceneVersion;
+  }
+  // if no room exists, consider the room saved so that we don't unnecessarily
+  // prevent unload (there's nothing we could do at that point anyway)
+  return true;
+};
+
+const getSyncableElementsFromResponse = async (response: Response) => {
+  return getSyncableElements(JSON.parse((await response.json()).data) || []);
+};
+
+// TODO (Jess): Consider adding reconciliation here, similar to firebase impl
+export const saveToHttpStorage = async (
+  portal: Portal,
+  elements: readonly ExcalidrawElement[],
+) => {
+  const { roomId, roomKey, socket } = portal;
+  if (
+    // if no room exists, consider the room saved because there's nothing we can
+    // do at this point
+    !roomId ||
+    !roomKey ||
+    !socket ||
+    isSavedToHttpStorage(portal, elements)
+  ) {
+    return true;
+  }
+
+  const sceneVersion = getSceneVersion(elements);
+
+  const getResponse = await fetch(`${HTTP_STORAGE_BACKEND_URL}/drawing-data`, {
+    method: "POST",
+    body: new URLSearchParams({
+      roomId,
+      roomKey,
+    }),
+  });
+
+  if (!getResponse.ok && getResponse.status !== 404) {
+    return false;
+  }
+
+  if (getResponse.ok) {
+    const existingElements = await getSyncableElementsFromResponse(getResponse);
+
+    if (existingElements && getSceneVersion(existingElements) >= sceneVersion) {
+      return false;
+    }
+  }
+
+  const putResponse = await fetch(`${HTTP_STORAGE_BACKEND_URL}/drawing-data`, {
+    method: "POST",
+    body: new URLSearchParams({
+      roomId,
+      roomKey,
+      data: JSON.stringify(elements),
+    }),
+  });
+
+  if (putResponse.ok) {
+    httpStorageSceneVersionCache.set(socket, sceneVersion);
+    return true;
+  }
+  return false;
+};
+
+// TODO (Jess): might need to look at getSceneVersion... new is using elements
+// as a whole, not just version number for the version cache
+export const loadFromHttpStorage = async (
+  roomId: string,
+  roomKey: string,
+  socket: Socket | null,
+): Promise<readonly ExcalidrawElement[] | null> => {
+  const getResponse = await fetch(`${HTTP_STORAGE_BACKEND_URL}/drawing-data`, {
+    method: "POST",
+    body: new URLSearchParams({
+      roomId,
+      roomKey,
+    }),
+  });
+
+  const elements = await getSyncableElementsFromResponse(getResponse);
+
+  if (socket) {
+    httpStorageSceneVersionCache.set(socket!, getSceneVersion(elements));
+  }
+
+  return restoreElements(elements, null);
+};
+
+export const saveFilesToHttpStorage = async ({
+  files,
+  roomId,
+  roomKey,
+}: {
+  files: { id: FileId; buffer: Uint8Array }[];
+  roomId: string;
+  roomKey: string;
+}) => {
+  const erroredFiles = new Map<FileId, true>();
+  const savedFiles = new Map<FileId, true>();
+
+  await Promise.all(
+    files.map(async ({ id, buffer }) => {
+      try {
+        const payloadBlob = new Blob([buffer]);
+        const body = await new Response(payloadBlob).arrayBuffer();
+
+        await fetch(`${HTTP_STORAGE_BACKEND_URL}/drawing-file`, {
+          method: "POST",
+          headers: {
+            "Room-Id": roomId,
+            "Room-Key": roomKey,
+            "File-Id": id,
+          },
+          body,
+        });
+        savedFiles.set(id, true);
+      } catch (error: any) {
+        erroredFiles.set(id, true);
+      }
+    }),
+  );
+
+  return { savedFiles, erroredFiles };
+};
+
+export const loadFilesFromHttpStorage = async (
+  filesIds: readonly FileId[],
+  roomId: string,
+  roomKey: string,
+) => {
+  const loadedFiles: BinaryFileData[] = [];
+  const erroredFiles = new Map<FileId, true>();
+
+  await Promise.all(
+    [...new Set(filesIds)].map(async (id) => {
+      try {
+        const response = await fetch(
+          `${HTTP_STORAGE_BACKEND_URL}/drawing-file`,
+          {
+            method: "GET",
+            headers: {
+              "Room-Id": roomId,
+              "Room-Key": roomKey,
+              "File-Id": id,
+            },
+          },
+        );
+        if (response.status < 400) {
+          const buffer = await response.arrayBuffer();
+
+          const { data, metadata } = await decompressData<BinaryFileMetadata>(
+            new Uint8Array(buffer),
+            {
+              decryptionKey: roomKey,
+            },
+          );
+
+          const dataURL = new TextDecoder().decode(data) as DataURL;
+
+          loadedFiles.push({
+            mimeType: metadata.mimeType || MIME_TYPES.binary,
+            id,
+            dataURL,
+            created: metadata?.created || Date.now(),
+            // TODO (Jess): consider adding:
+            // lastRetrieved: metadata?.created || Date.now(),
+          });
+        } else {
+          erroredFiles.set(id, true);
+        }
+      } catch (error: any) {
+        erroredFiles.set(id, true);
+        console.error(error);
+      }
+    }),
+  );
+
+  return { loadedFiles, erroredFiles };
+};

--- a/excalidraw-app/data/index.ts
+++ b/excalidraw-app/data/index.ts
@@ -51,10 +51,11 @@ export const isSyncableElement = (
   return !isInvisiblySmallElement(element);
 };
 
-export const getSyncableElements = (elements: readonly ExcalidrawElement[]) =>
-  elements.filter((element) =>
+export const getSyncableElements = (elements: readonly ExcalidrawElement[]) => {
+  return elements.filter((element) =>
     isSyncableElement(element),
   ) as SyncableExcalidrawElement[];
+};
 
 const BACKEND_V2_GET = import.meta.env.VITE_APP_BACKEND_V2_GET_URL;
 const BACKEND_V2_POST = import.meta.env.VITE_APP_BACKEND_V2_POST_URL;
@@ -132,10 +133,11 @@ export const isCollaborationLink = (link: string) => {
 export const getCollaborationLinkData = (link: string) => {
   const hash = new URL(link).hash;
   const match = hash.match(RE_COLLAB_LINK);
-  if (match && match[2].length !== 22) {
-    window.alert(t("alerts.invalidEncryptionKey"));
-    return null;
-  }
+  // TODO (Jess): Add this back in if we are using encrypted room keys
+  // if (match && match[2].length !== 22) {
+  //   window.alert(t("alerts.invalidEncryptionKey"));
+  //   return null;
+  // }
   return match ? { roomId: match[1], roomKey: match[2] } : null;
 };
 

--- a/excalidraw-app/vite.config.mts
+++ b/excalidraw-app/vite.config.mts
@@ -10,7 +10,7 @@ const envVars = loadEnv("", `../`);
 // https://vitejs.dev/config/
 export default defineConfig({
   server: {
-    port: Number(envVars.VITE_APP_PORT || 3000),
+    port: Number(envVars.VITE_APP_PORT || 3003),
     // open the browser
     open: true,
   },

--- a/packages/excalidraw/data/encryption.ts
+++ b/packages/excalidraw/data/encryption.ts
@@ -46,34 +46,36 @@ export const getCryptoKey = (key: string, usage: KeyUsage) =>
     [usage],
   );
 
+// TODO (Jess): Reconsider if we want to use this
 export const encryptData = async (
   key: string | CryptoKey,
   data: Uint8Array | ArrayBuffer | Blob | File | string,
 ): Promise<{ encryptedBuffer: ArrayBuffer; iv: Uint8Array }> => {
-  const importedKey =
-    typeof key === "string" ? await getCryptoKey(key, "encrypt") : key;
-  const iv = createIV();
-  const buffer: ArrayBuffer | Uint8Array =
-    typeof data === "string"
-      ? new TextEncoder().encode(data)
-      : data instanceof Uint8Array
-      ? data
-      : data instanceof Blob
-      ? await blobToArrayBuffer(data)
-      : data;
+  // const importedKey =
+  //   typeof key === "string" ? await getCryptoKey(key, "encrypt") : key;
+  // const iv = createIV();
+  // const buffer: ArrayBuffer | Uint8Array =
+  //   typeof data === "string"
+  //     ? new TextEncoder().encode(data)
+  //     : data instanceof Uint8Array
+  //     ? data
+  //     : data instanceof Blob
+  //     ? await blobToArrayBuffer(data)
+  //     : data;
 
-  // We use symmetric encryption. AES-GCM is the recommended algorithm and
-  // includes checks that the ciphertext has not been modified by an attacker.
-  const encryptedBuffer = await window.crypto.subtle.encrypt(
-    {
-      name: "AES-GCM",
-      iv,
-    },
-    importedKey,
-    buffer as ArrayBuffer | Uint8Array,
-  );
+  // // We use symmetric encryption. AES-GCM is the recommended algorithm and
+  // // includes checks that the ciphertext has not been modified by an attacker.
+  // const encryptedBuffer = await window.crypto.subtle.encrypt(
+  //   {
+  //     name: "AES-GCM",
+  //     iv,
+  //   },
+  //   importedKey,
+  //   buffer as ArrayBuffer | Uint8Array,
+  // );
 
-  return { encryptedBuffer, iv };
+  // return { encryptedBuffer, iv };
+  return { encryptedBuffer: data as ArrayBuffer, iv: createIV() };
 };
 
 export const decryptData = async (
@@ -81,13 +83,14 @@ export const decryptData = async (
   encrypted: Uint8Array | ArrayBuffer,
   privateKey: string,
 ): Promise<ArrayBuffer> => {
-  const key = await getCryptoKey(privateKey, "decrypt");
-  return window.crypto.subtle.decrypt(
-    {
-      name: "AES-GCM",
-      iv,
-    },
-    key,
-    encrypted,
-  );
+  // const key = await getCryptoKey(privateKey, "decrypt");
+  // return window.crypto.subtle.decrypt(
+  //   {
+  //     name: "AES-GCM",
+  //     iv,
+  //   },
+  //   key,
+  //   encrypted,
+  // );
+  return encrypted as ArrayBuffer;
 };


### PR DESCRIPTION
## Description

Add a new storage method that will load/save drawings and drawing files from a local http server. Use this instead of the default firebase implementation.

## Tests performed

- When in collaboration mode, all drawing elements and files are successfully saved
- Opening the collaboration link successfully loads all drawing elements and files
- Real-time edits are broadcast and saved successfully
- All app tests are passing