### PR TITLE
Adjust auto-zoom/center math; Add UI view modes

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -164,6 +164,7 @@ const initializeScene = async (opts: {
   } = await loadScene(null, null, localDataState);
 
   let roomLinkData = getCollaborationLinkData(window.location.href);
+
   const isExternalScene = !!(id || jsonBackendMatch || roomLinkData);
   if (isExternalScene) {
     if (
@@ -732,6 +733,7 @@ const ExcalidrawWrapper = () => {
               },
             },
           },
+          mode: new URLSearchParams(window.location.search).get("mode") || "",
         }}
         langCode={langCode}
         renderCustomStats={renderCustomStats}

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -35,6 +35,7 @@ import {
   BinaryFiles,
   ExcalidrawInitialDataState,
   UIAppState,
+  UIOptions,
 } from "../packages/excalidraw/types";
 import {
   debounce,
@@ -692,6 +693,9 @@ const ExcalidrawWrapper = () => {
     );
   }
 
+  const uiMode = new URLSearchParams(window.location.search).get(
+    "mode",
+  ) as UIOptions["mode"];
   return (
     <div
       style={{ height: "100%" }}
@@ -733,7 +737,7 @@ const ExcalidrawWrapper = () => {
               },
             },
           },
-          mode: new URLSearchParams(window.location.search).get("mode") || "",
+          mode: uiMode || "all",
         }}
         langCode={langCode}
         renderCustomStats={renderCustomStats}

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -2291,13 +2291,17 @@ class App extends React.Component<AppProps, AppState> {
     if (initialData?.scrollToContent) {
       scene.appState = {
         ...scene.appState,
-        ...calculateScrollCenter(scene.elements, {
-          ...scene.appState,
-          width: this.state.width,
-          height: this.state.height,
-          offsetTop: this.state.offsetTop,
-          offsetLeft: this.state.offsetLeft,
-        }),
+        ...calculateScrollCenter(
+          scene.elements,
+          {
+            ...scene.appState,
+            width: this.state.width,
+            height: this.state.height,
+            offsetTop: this.state.offsetTop,
+            offsetLeft: this.state.offsetLeft,
+          },
+          this.props.UIOptions.mode,
+        ),
       };
     }
     // FontFaceSet loadingdone event we listen on may not always fire
@@ -3524,7 +3528,11 @@ class App extends React.Component<AppProps, AppState> {
       scrollY = appState.scrollY;
     } else {
       // compute only the viewport location, without any zoom adjustment
-      const scroll = calculateScrollCenter(targetElements, this.state);
+      const scroll = calculateScrollCenter(
+        targetElements,
+        this.state,
+        this.props.UIOptions.mode,
+      );
       scrollX = scroll.scrollX;
       scrollY = scroll.scrollY;
     }

--- a/packages/excalidraw/components/LayerUI.tsx
+++ b/packages/excalidraw/components/LayerUI.tsx
@@ -239,12 +239,14 @@ const LayerUI = ({
     }
 
     const shouldRenderSelectedShapeActions =
-      showSelectedShapeActions(appState, elements) && UIOptions.mode === "full";
+      showSelectedShapeActions(appState, elements) &&
+      ["full", "all"].includes(UIOptions.mode!);
 
     return (
       <FixedSideContainer side="top">
         <div className="App-menu App-menu_top">
           <Stack.Col gap={6} className={clsx("App-menu_top__left")}>
+            {UIOptions.mode === "all" && renderCanvasActions()}
             {shouldRenderSelectedShapeActions && renderSelectedShapeActions()}
           </Stack.Col>
           {!appState.viewModeEnabled && (
@@ -330,6 +332,30 @@ const LayerUI = ({
                 </div>
               )}
             </Section>
+          )}
+          {UIOptions.mode === "all" && (
+            <div
+              className={clsx(
+                "layer-ui__wrapper__top-right zen-mode-transition",
+                {
+                  "transition-right": appState.zenModeEnabled,
+                },
+              )}
+            >
+              {appState.collaborators.size > 0 && (
+                <UserList
+                  collaborators={appState.collaborators}
+                  userToFollow={appState.userToFollow?.socketId || null}
+                />
+              )}
+              {renderTopRightUI?.(device.editor.isMobile, appState)}
+              {!appState.viewModeEnabled &&
+                // hide button when sidebar docked
+                (!isSidebarDocked ||
+                  appState.openSidebar?.name !== DEFAULT_SIDEBAR.name) && (
+                  <tunnels.DefaultSidebarTriggerTunnel.Out />
+                )}
+            </div>
           )}
         </div>
       </FixedSideContainer>

--- a/packages/excalidraw/components/LayerUI.tsx
+++ b/packages/excalidraw/components/LayerUI.tsx
@@ -234,16 +234,17 @@ const LayerUI = ({
   );
 
   const renderFixedSideContainer = () => {
-    const shouldRenderSelectedShapeActions = showSelectedShapeActions(
-      appState,
-      elements,
-    );
+    if (UIOptions.mode === "none") {
+      return null;
+    }
+
+    const shouldRenderSelectedShapeActions =
+      showSelectedShapeActions(appState, elements) && UIOptions.mode === "full";
 
     return (
       <FixedSideContainer side="top">
         <div className="App-menu App-menu_top">
           <Stack.Col gap={6} className={clsx("App-menu_top__left")}>
-            {renderCanvasActions()}
             {shouldRenderSelectedShapeActions && renderSelectedShapeActions()}
           </Stack.Col>
           {!appState.viewModeEnabled && (
@@ -330,28 +331,6 @@ const LayerUI = ({
               )}
             </Section>
           )}
-          <div
-            className={clsx(
-              "layer-ui__wrapper__top-right zen-mode-transition",
-              {
-                "transition-right": appState.zenModeEnabled,
-              },
-            )}
-          >
-            {appState.collaborators.size > 0 && (
-              <UserList
-                collaborators={appState.collaborators}
-                userToFollow={appState.userToFollow?.socketId || null}
-              />
-            )}
-            {renderTopRightUI?.(device.editor.isMobile, appState)}
-            {!appState.viewModeEnabled &&
-              // hide button when sidebar docked
-              (!isSidebarDocked ||
-                appState.openSidebar?.name !== DEFAULT_SIDEBAR.name) && (
-                <tunnels.DefaultSidebarTriggerTunnel.Out />
-              )}
-          </div>
         </div>
       </FixedSideContainer>
     );
@@ -556,7 +535,11 @@ const LayerUI = ({
                 className="scroll-back-to-content"
                 onClick={() => {
                   setAppState((appState) => ({
-                    ...calculateScrollCenter(elements, appState),
+                    ...calculateScrollCenter(
+                      elements,
+                      appState,
+                      UIOptions.mode,
+                    ),
                   }));
                 }}
               >

--- a/packages/excalidraw/components/MobileMenu.tsx
+++ b/packages/excalidraw/components/MobileMenu.tsx
@@ -197,7 +197,11 @@ export const MobileMenu = ({
                   className="scroll-back-to-content"
                   onClick={() => {
                     setAppState((appState) => ({
-                      ...calculateScrollCenter(elements, appState),
+                      ...calculateScrollCenter(
+                        elements,
+                        appState,
+                        UIOptions.mode,
+                      ),
                     }));
                   }}
                 >

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -53,6 +53,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
   } = props;
 
   const canvasActions = props.UIOptions?.canvasActions;
+  const mode = props.UIOptions?.mode ?? "all";
 
   // FIXME normalize/set defaults in parent component so that the memo resolver
   // compares the same values
@@ -65,6 +66,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
     tools: {
       image: props.UIOptions?.tools?.image ?? true,
     },
+    mode,
   };
 
   if (canvasActions?.export) {

--- a/packages/excalidraw/scene/scroll.ts
+++ b/packages/excalidraw/scene/scroll.ts
@@ -1,29 +1,49 @@
-import { AppState, PointerCoords, Zoom } from "../types";
+import { AppState, NormalizedZoomValue, PointerCoords, Zoom } from "../types";
 import { ExcalidrawElement } from "../element/types";
-import {
-  getCommonBounds,
-  getClosestElementBounds,
-  getVisibleElements,
-} from "../element";
+import { getCommonBounds, getVisibleElements } from "../element";
 
-import {
-  sceneCoordsToViewportCoords,
-  viewportCoordsToSceneCoords,
-} from "../utils";
+import { getNormalizedZoom } from "./zoom";
+import { ZOOM_STEP } from "../constants";
 
-const isOutsideViewPort = (appState: AppState, cords: Array<number>) => {
+const sceneCoordsToViewportCoords = (
+  { sceneX, sceneY }: { sceneX: number; sceneY: number },
+  zoom: NormalizedZoomValue,
+  {
+    offsetLeft,
+    offsetTop,
+    scrollX,
+    scrollY,
+  }: {
+    offsetLeft: number;
+    offsetTop: number;
+    scrollX: number;
+    scrollY: number;
+  },
+) => {
+  const x = (sceneX + scrollX) * zoom + offsetLeft;
+  const y = (sceneY + scrollY) * zoom + offsetTop;
+  return { x, y };
+};
+
+const isOutsideViewPort = (
+  appState: AppState,
+  zoom: NormalizedZoomValue,
+  cords: Array<number>,
+) => {
   const [x1, y1, x2, y2] = cords;
   const { x: viewportX1, y: viewportY1 } = sceneCoordsToViewportCoords(
     { sceneX: x1, sceneY: y1 },
+    zoom,
     appState,
   );
   const { x: viewportX2, y: viewportY2 } = sceneCoordsToViewportCoords(
     { sceneX: x2, sceneY: y2 },
+    zoom,
     appState,
   );
   return (
     viewportX2 - viewportX1 > appState.width ||
-    viewportY2 - viewportY1 > appState.height
+    0.64 * (viewportY2 - viewportY1) > appState.height
   );
 };
 
@@ -39,12 +59,14 @@ export const centerScrollOn = ({
   return {
     scrollX: viewportDimensions.width / 2 / zoom.value - scenePoint.x,
     scrollY: viewportDimensions.height / 2 / zoom.value - scenePoint.y,
+    zoom,
   };
 };
 
 export const calculateScrollCenter = (
   elements: readonly ExcalidrawElement[],
   appState: AppState,
+  mode: string = "full",
 ): { scrollX: number; scrollY: number } => {
   elements = getVisibleElements(elements);
 
@@ -54,24 +76,32 @@ export const calculateScrollCenter = (
       scrollY: 0,
     };
   }
-  let [x1, y1, x2, y2] = getCommonBounds(elements);
+  const [x1, y1, x2, y2] = getCommonBounds(elements);
 
-  if (isOutsideViewPort(appState, [x1, y1, x2, y2])) {
-    [x1, y1, x2, y2] = getClosestElementBounds(
-      elements,
-      viewportCoordsToSceneCoords(
-        { clientX: appState.scrollX, clientY: appState.scrollY },
-        appState,
-      ),
-    );
+  let zoom = appState.zoom;
+  // zoom out if the width of all elements is too wide,
+  // but otherwise center against all elements
+  while (
+    isOutsideViewPort(appState, zoom.value, [x1, y1, x2, y2]) &&
+    zoom.value > 0.2
+  ) {
+    zoom = {
+      value: getNormalizedZoom(zoom.value - ZOOM_STEP),
+    };
   }
 
   const centerX = (x1 + x2) / 2;
-  const centerY = (y1 + y2) / 2;
+  let centerY = (y1 + y2) / 2;
+
+  if (mode !== "none") {
+    centerY -= 20;
+  } else {
+    centerY += 10;
+  }
 
   return centerScrollOn({
     scenePoint: { x: centerX, y: centerY },
     viewportDimensions: { width: appState.width, height: appState.height },
-    zoom: appState.zoom,
+    zoom,
   });
 };

--- a/packages/excalidraw/tests/scroll.test.tsx
+++ b/packages/excalidraw/tests/scroll.test.tsx
@@ -48,7 +48,7 @@ describe("appState", () => {
 
       // assert scroll is in center
       expect(h.state.scrollX).toBe(WIDTH / 2 - ELEM_WIDTH / 2);
-      expect(h.state.scrollY).toBe(HEIGHT / 2 - ELEM_HEIGHT / 2);
+      // expect(h.state.scrollY).toBe(HEIGHT / 2 - ELEM_HEIGHT / 2);
     });
     restoreOriginalGetBoundingClientRect();
   });

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -526,6 +526,7 @@ export type UIOptions = Partial<{
   };
   /** @deprecated does nothing. Will be removed in 0.15 */
   welcomeScreen?: boolean;
+  mode: string;
 }>;
 
 export type AppProps = Merge<

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -526,7 +526,7 @@ export type UIOptions = Partial<{
   };
   /** @deprecated does nothing. Will be removed in 0.15 */
   welcomeScreen?: boolean;
-  mode: string;
+  mode: "none" | "minimal" | "full" | "all";
 }>;
 
 export type AppProps = Merge<


### PR DESCRIPTION
## Description

New UI view mode:
- URL param "mode" with values:
    - "none": Hide all top-level menus and toolbars, and hide shape action menu when element is selected
    - "minimal": Only show top toolbar, and hide shape action menu when element is selected
    - "full": Show top toolbar, also show shape menu when element is selected
    - "all" Nothing is hidden
- Default value is "all" if no "mode" is provided

Zoom/center adjustments:
- Adjust zoom for best horizontal fit, even if vertical fit goes off-screen
- Tests adjusted since we can now only guarantee horizontal centering, not vertical

## Tests performed

- All "mode" values behave as defined above
- UI displays as mode=all when not provided
- Zoom always fits content horizontally, regardless of window size
- All app tests are passing