### PR TITLE
Disable/modify keyboard shortcuts, misc changes

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -283,7 +283,7 @@ export const appLangCodeAtom = atom(
 const ExcalidrawWrapper = () => {
   const [errorMessage, setErrorMessage] = useState("");
   const [langCode, setLangCode] = useAtom(appLangCodeAtom);
-  const isCollabDisabled = isRunningInIframe();
+  const isCollabDisabled = false;
 
   // initial state
   // ---------------------------------------------------------------------------

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -787,7 +787,6 @@ const ExcalidrawWrapper = () => {
             </OverwriteConfirmDialog.Action>
           )}
         </OverwriteConfirmDialog>
-        <AppFooter />
         <TTDDialog
           onTextSubmit={async (input) => {
             try {

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -46,6 +46,7 @@ import {
   ResolvablePromise,
   resolvablePromise,
   isRunningInIframe,
+  getUiMode,
 } from "../packages/excalidraw/utils";
 import {
   FIREBASE_STORAGE_PREFIXES,
@@ -693,9 +694,7 @@ const ExcalidrawWrapper = () => {
     );
   }
 
-  const uiMode = new URLSearchParams(window.location.search).get(
-    "mode",
-  ) as UIOptions["mode"];
+  const uiMode = getUiMode();
   return (
     <div
       style={{ height: "100%" }}

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -35,7 +35,6 @@ import {
   BinaryFiles,
   ExcalidrawInitialDataState,
   UIAppState,
-  UIOptions,
 } from "../packages/excalidraw/types";
 import {
   debounce,
@@ -45,7 +44,6 @@ import {
   preventUnload,
   ResolvablePromise,
   resolvablePromise,
-  isRunningInIframe,
   getUiMode,
 } from "../packages/excalidraw/utils";
 import {
@@ -94,7 +92,6 @@ import {
 } from "../packages/excalidraw/data/library";
 import { AppMainMenu } from "./components/AppMainMenu";
 import { AppWelcomeScreen } from "./components/AppWelcomeScreen";
-import { AppFooter } from "./components/AppFooter";
 import { atom, Provider, useAtom, useAtomValue } from "jotai";
 import { useAtomWithInitialValue } from "../packages/excalidraw/jotai";
 import { appJotaiStore } from "./app-jotai";

--- a/packages/excalidraw/actions/actionDeleteSelected.tsx
+++ b/packages/excalidraw/actions/actionDeleteSelected.tsx
@@ -11,7 +11,7 @@ import { getElementsInGroup } from "../groups";
 import { LinearElementEditor } from "../element/linearElementEditor";
 import { fixBindingsAfterDeletion } from "../element/binding";
 import { isBoundToContainer, isFrameLikeElement } from "../element/typeChecks";
-import { updateActiveTool } from "../utils";
+import { getUiMode, updateActiveTool } from "../utils";
 import { TrashIcon } from "../components/icons";
 
 const deleteSelectedElements = (
@@ -169,8 +169,13 @@ export const actionDeleteSelected = register({
   },
   contextItemLabel: "labels.delete",
   keyTest: (event, appState, elements) =>
-    (event.key === KEYS.BACKSPACE || event.key === KEYS.DELETE) &&
-    !event[KEYS.CTRL_OR_CMD],
+    getUiMode() === "all"
+      ? (event.key === KEYS.BACKSPACE || event.key === KEYS.DELETE) &&
+        !event[KEYS.CTRL_OR_CMD]
+      : // in other ui modes, only delete element on cmd+backspace (instead of just backspace)
+        // (this means cmd+backspace will no longer trigger canvas clear)
+        (event.key === KEYS.BACKSPACE || event.key === KEYS.DELETE) &&
+        event[KEYS.CTRL_OR_CMD],
   PanelComponent: ({ elements, appState, updateData }) => (
     <ToolButton
       type="button"

--- a/packages/excalidraw/actions/actionToggleZenMode.tsx
+++ b/packages/excalidraw/actions/actionToggleZenMode.tsx
@@ -1,4 +1,5 @@
 import { CODES, KEYS } from "../keys";
+import { getUiMode } from "../utils";
 import { register } from "./register";
 
 export const actionToggleZenMode = register({
@@ -23,5 +24,7 @@ export const actionToggleZenMode = register({
   },
   contextItemLabel: "buttons.zenMode",
   keyTest: (event) =>
-    !event[KEYS.CTRL_OR_CMD] && event.altKey && event.code === CODES.Z,
+    getUiMode() === "all"
+      ? !event[KEYS.CTRL_OR_CMD] && event.altKey && event.code === CODES.Z
+      : false,
 });

--- a/packages/excalidraw/actions/actionZindex.tsx
+++ b/packages/excalidraw/actions/actionZindex.tsx
@@ -15,6 +15,7 @@ import {
   SendBackwardIcon,
   SendToBackIcon,
 } from "../components/icons";
+import { ToolButton } from "../components/ToolButton";
 import { isDarwin } from "../constants";
 
 export const actionSendBackward = register({
@@ -34,14 +35,13 @@ export const actionSendBackward = register({
     !event.shiftKey &&
     event.code === CODES.BRACKET_LEFT,
   PanelComponent: ({ updateData, appState }) => (
-    <button
+    <ToolButton
       type="button"
-      className="zIndexButton"
+      icon={SendBackwardIcon}
       onClick={() => updateData(null)}
       title={`${t("labels.sendBackward")} — ${getShortcutKey("CtrlOrCmd+[")}`}
-    >
-      {SendBackwardIcon}
-    </button>
+      aria-label={t("labels.sendBackward")}
+    />
   ),
 });
 
@@ -62,14 +62,13 @@ export const actionBringForward = register({
     !event.shiftKey &&
     event.code === CODES.BRACKET_RIGHT,
   PanelComponent: ({ updateData, appState }) => (
-    <button
+    <ToolButton
       type="button"
-      className="zIndexButton"
+      icon={BringForwardIcon}
       onClick={() => updateData(null)}
       title={`${t("labels.bringForward")} — ${getShortcutKey("CtrlOrCmd+]")}`}
-    >
-      {BringForwardIcon}
-    </button>
+      aria-label={t("labels.bringForward")}
+    />
   ),
 });
 
@@ -93,18 +92,17 @@ export const actionSendToBack = register({
         event.shiftKey &&
         event.code === CODES.BRACKET_LEFT,
   PanelComponent: ({ updateData, appState }) => (
-    <button
+    <ToolButton
       type="button"
-      className="zIndexButton"
+      icon={SendToBackIcon}
       onClick={() => updateData(null)}
       title={`${t("labels.sendToBack")} — ${
         isDarwin
           ? getShortcutKey("CtrlOrCmd+Alt+[")
           : getShortcutKey("CtrlOrCmd+Shift+[")
       }`}
-    >
-      {SendToBackIcon}
-    </button>
+      aria-label={t("labels.sendToBack")}
+    />
   ),
 });
 
@@ -129,17 +127,16 @@ export const actionBringToFront = register({
         event.shiftKey &&
         event.code === CODES.BRACKET_RIGHT,
   PanelComponent: ({ updateData, appState }) => (
-    <button
+    <ToolButton
       type="button"
-      className="zIndexButton"
-      onClick={(event) => updateData(null)}
+      icon={BringToFrontIcon}
+      onClick={() => updateData(null)}
       title={`${t("labels.bringToFront")} — ${
         isDarwin
           ? getShortcutKey("CtrlOrCmd+Alt+]")
           : getShortcutKey("CtrlOrCmd+Shift+]")
       }`}
-    >
-      {BringToFrontIcon}
-    </button>
+      aria-label={t("labels.bringToFront")}
+    />
   ),
 });

--- a/packages/excalidraw/analytics.ts
+++ b/packages/excalidraw/analytics.ts
@@ -1,40 +1,9 @@
-// place here categories that you want to track. We want to track just a
-// small subset of categories at a given time.
-const ALLOWED_CATEGORIES_TO_TRACK = ["ai"] as string[];
-
 export const trackEvent = (
   category: string,
   action: string,
   label?: string,
   value?: number,
 ) => {
-  try {
-    // prettier-ignore
-    if (
-      typeof window === "undefined"
-      || import.meta.env.VITE_WORKER_ID
-      // comment out to debug locally
-      || import.meta.env.PROD
-    ) {
-      return;
-    }
-
-    if (!ALLOWED_CATEGORIES_TO_TRACK.includes(category)) {
-      return;
-    }
-
-    if (!import.meta.env.PROD) {
-      console.info("trackEvent", { category, action, label, value });
-    }
-
-    if (window.sa_event) {
-      window.sa_event(action, {
-        category,
-        label,
-        value,
-      });
-    }
-  } catch (error) {
-    console.error("error during analytics", error);
-  }
+  // Uncomment the next line to track locally
+  // console.log("Track Event", { category, action, label, value });
 };

--- a/packages/excalidraw/components/LockButton.tsx
+++ b/packages/excalidraw/components/LockButton.tsx
@@ -3,6 +3,7 @@ import "./ToolIcon.scss";
 import clsx from "clsx";
 import { ToolButtonSize } from "./ToolButton";
 import { LockedIcon, UnlockedIcon } from "./icons";
+import { getUiMode } from "../utils";
 
 type LockIconProps = {
   title?: string;
@@ -29,7 +30,7 @@ export const LockButton = (props: LockIconProps) => {
           "is-mobile": props.isMobile,
         },
       )}
-      title={`${props.title} — Q`}
+      title={`${props.title}${getUiMode() === "all" ? " — Q" : ""}`}
     >
       <input
         className="ToolIcon_type_checkbox"

--- a/packages/excalidraw/components/ToolButton.tsx
+++ b/packages/excalidraw/components/ToolButton.tsx
@@ -6,7 +6,7 @@ import { useExcalidrawContainer } from "./App";
 import { AbortError } from "../errors";
 import Spinner from "./Spinner";
 import { PointerType } from "../element/types";
-import { isPromiseLike } from "../utils";
+import { getUiMode, isPromiseLike } from "../utils";
 
 export type ToolButtonSize = "small" | "medium";
 
@@ -54,6 +54,15 @@ type ToolButtonProps =
     });
 
 export const ToolButton = React.forwardRef((props: ToolButtonProps, ref) => {
+  let title = props.title;
+  if (
+    title &&
+    (title.includes("-") || title.includes("–") || title.includes("—")) &&
+    getUiMode() !== "all"
+  ) {
+    title = title.split(/[-–—]/)[0].trim();
+  }
+
   const { id: excalId } = useExcalidrawContainer();
   const innerRef = React.useRef(null);
   React.useImperativeHandle(ref, () => innerRef.current);
@@ -119,7 +128,7 @@ export const ToolButton = React.forwardRef((props: ToolButtonProps, ref) => {
         style={props.style}
         data-testid={props["data-testid"]}
         hidden={props.hidden}
-        title={props.title}
+        title={title}
         aria-label={props["aria-label"]}
         type={type}
         onClick={onClick}
@@ -150,7 +159,7 @@ export const ToolButton = React.forwardRef((props: ToolButtonProps, ref) => {
   return (
     <label
       className={clsx("ToolIcon", props.className)}
-      title={props.title}
+      title={title}
       onPointerDown={(event) => {
         lastPointerTypeRef.current = event.pointerType || null;
         props.onPointerDown?.({ pointerType: event.pointerType || null });

--- a/packages/excalidraw/components/footer/Footer.tsx
+++ b/packages/excalidraw/components/footer/Footer.tsx
@@ -13,6 +13,7 @@ import { HelpButton } from "../HelpButton";
 import { Section } from "../Section";
 import Stack from "../Stack";
 import { UIAppState } from "../../types";
+import { getUiMode } from "../../utils";
 
 const Footer = ({
   appState,
@@ -26,6 +27,7 @@ const Footer = ({
   renderWelcomeScreen: boolean;
 }) => {
   const { FooterCenterTunnel, WelcomeScreenHelpHintTunnel } = useTunnels();
+  const uiMode = getUiMode();
 
   const device = useDevice();
   const showFinalize =
@@ -78,9 +80,11 @@ const Footer = ({
       >
         <div style={{ position: "relative" }}>
           {renderWelcomeScreen && <WelcomeScreenHelpHintTunnel.Out />}
-          <HelpButton
-            onClick={() => actionManager.executeAction(actionShortcuts)}
-          />
+          {uiMode === "all" && (
+            <HelpButton
+              onClick={() => actionManager.executeAction(actionShortcuts)}
+            />
+          )}
         </div>
       </div>
       <ExitZenModeAction

--- a/packages/excalidraw/constants.ts
+++ b/packages/excalidraw/constants.ts
@@ -231,6 +231,7 @@ export const DEFAULT_UI_OPTIONS: AppProps["UIOptions"] = {
   tools: {
     image: true,
   },
+  mode: "all",
 };
 
 // breakpoints

--- a/packages/excalidraw/constants.ts
+++ b/packages/excalidraw/constants.ts
@@ -199,7 +199,7 @@ export const TOUCH_CTX_MENU_TIMEOUT = 500;
 export const TITLE_TIMEOUT = 10000;
 export const VERSION_TIMEOUT = 30000;
 export const SCROLL_TIMEOUT = 100;
-export const ZOOM_STEP = 0.1;
+export const ZOOM_STEP = 0.05;
 export const MIN_ZOOM = 0.1;
 export const HYPERLINK_TOOLTIP_DELAY = 300;
 

--- a/packages/excalidraw/element/textWysiwyg.test.tsx
+++ b/packages/excalidraw/element/textWysiwyg.test.tsx
@@ -439,21 +439,21 @@ describe("textWysiwyg", () => {
           ctrlKey: true,
         }),
       );
-      expect(h.state.zoom.value).toBe(0.9);
+      expect(h.state.zoom.value).toBe(0.95);
       textarea.dispatchEvent(
         new KeyboardEvent("keydown", {
           code: CODES.NUM_SUBTRACT,
           ctrlKey: true,
         }),
       );
-      expect(h.state.zoom.value).toBe(0.8);
+      expect(h.state.zoom.value).toBe(0.9);
       textarea.dispatchEvent(
         new KeyboardEvent("keydown", {
           code: CODES.NUM_ADD,
           ctrlKey: true,
         }),
       );
-      expect(h.state.zoom.value).toBe(0.9);
+      expect(h.state.zoom.value).toBe(0.95);
       textarea.dispatchEvent(
         new KeyboardEvent("keydown", {
           code: CODES.EQUAL,

--- a/packages/excalidraw/index.tsx
+++ b/packages/excalidraw/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { InitializeApp } from "./components/InitializeApp";
 import App from "./components/App";
-import { isShallowEqual } from "./utils";
+import { getUiMode, isShallowEqual } from "./utils";
 
 import "./css/app.scss";
 import "./css/styles.scss";
@@ -53,7 +53,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
   } = props;
 
   const canvasActions = props.UIOptions?.canvasActions;
-  const mode = props.UIOptions?.mode ?? "all";
+  const uiMode = getUiMode();
 
   // FIXME normalize/set defaults in parent component so that the memo resolver
   // compares the same values
@@ -66,7 +66,7 @@ const ExcalidrawBase = (props: ExcalidrawProps) => {
     tools: {
       image: props.UIOptions?.tools?.image ?? true,
     },
-    mode,
+    mode: uiMode,
   };
 
   if (canvasActions?.export) {

--- a/packages/excalidraw/keys.ts
+++ b/packages/excalidraw/keys.ts
@@ -89,9 +89,11 @@ const ENABLED_KEYS = new Set([
   "DELETE",
   "BACKSPACE",
   "Z",
-  "SHIFT",
   "CTRL_OR_CMD",
+  "SPACE",
 ]);
+
+const ENABLED_CODES = new Set(["Z"]);
 
 const keysProxy = {
   get(target: typeof INTERNAL_KEYS, key: string) {
@@ -103,7 +105,7 @@ const keysProxy = {
 
 const codesProxy = {
   get(target: typeof INTERNAL_CODES, key: string) {
-    return getUiMode() === "all" || ENABLED_KEYS.has(key as any)
+    return getUiMode() === "all" || ENABLED_CODES.has(key as any)
       ? target[key as keyof typeof INTERNAL_CODES]
       : "";
   },

--- a/packages/excalidraw/keys.ts
+++ b/packages/excalidraw/keys.ts
@@ -1,6 +1,7 @@
 import { isDarwin } from "./constants";
+import { getUiMode } from "./utils";
 
-export const CODES = {
+const INTERNAL_CODES = {
   EQUAL: "Equal",
   MINUS: "Minus",
   NUM_ADD: "NumpadAdd",
@@ -24,7 +25,7 @@ export const CODES = {
   S: "KeyS",
 } as const;
 
-export const KEYS = {
+const INTERNAL_KEYS = {
   ARROW_DOWN: "ArrowDown",
   ARROW_LEFT: "ArrowLeft",
   ARROW_RIGHT: "ArrowRight",
@@ -79,6 +80,37 @@ export const KEYS = {
   8: "8",
   9: "9",
 } as const;
+
+// Only key combos using 1 or more of these keys will be allowed
+// when not in ui mode "all"
+const ENABLED_KEYS = new Set([
+  "ENTER",
+  "ESCAPE",
+  "DELETE",
+  "BACKSPACE",
+  "Z",
+  "SHIFT",
+  "CTRL_OR_CMD",
+]);
+
+const keysProxy = {
+  get(target: typeof INTERNAL_KEYS, key: string) {
+    return getUiMode() === "all" || ENABLED_KEYS.has(key as any)
+      ? target[key as keyof typeof INTERNAL_KEYS]
+      : "";
+  },
+};
+
+const codesProxy = {
+  get(target: typeof INTERNAL_CODES, key: string) {
+    return getUiMode() === "all" || ENABLED_KEYS.has(key as any)
+      ? target[key as keyof typeof INTERNAL_CODES]
+      : "";
+  },
+};
+
+export const KEYS = new Proxy(INTERNAL_KEYS, keysProxy);
+export const CODES = new Proxy(INTERNAL_CODES, codesProxy);
 
 export type Key = keyof typeof KEYS;
 

--- a/packages/excalidraw/scene/scroll.ts
+++ b/packages/excalidraw/scene/scroll.ts
@@ -86,7 +86,7 @@ export const calculateScrollCenter = (
     zoom.value > 0.2
   ) {
     zoom = {
-      value: getNormalizedZoom(zoom.value - ZOOM_STEP),
+      value: getNormalizedZoom(zoom.value - 0.02),
     };
   }
 

--- a/packages/excalidraw/scene/scroll.ts
+++ b/packages/excalidraw/scene/scroll.ts
@@ -3,7 +3,6 @@ import { ExcalidrawElement } from "../element/types";
 import { getCommonBounds, getVisibleElements } from "../element";
 
 import { getNormalizedZoom } from "./zoom";
-import { ZOOM_STEP } from "../constants";
 
 const sceneCoordsToViewportCoords = (
   { sceneX, sceneY }: { sceneX: number; sceneY: number },

--- a/packages/excalidraw/scene/zoom.ts
+++ b/packages/excalidraw/scene/zoom.ts
@@ -2,7 +2,10 @@ import { MIN_ZOOM } from "../constants";
 import { AppState, NormalizedZoomValue } from "../types";
 
 export const getNormalizedZoom = (zoom: number): NormalizedZoomValue => {
-  return Math.max(MIN_ZOOM, Math.min(zoom, 30)) as NormalizedZoomValue;
+  // We round to 2 decimal places to avoid floating point math issues
+  // due to changing default zoom step to 0.05 from 0.1
+  return (Math.round(Math.max(MIN_ZOOM, Math.min(zoom, 30)) * 100) /
+    100) as NormalizedZoomValue;
 };
 
 export const getStateForZoom = (

--- a/packages/excalidraw/utils.ts
+++ b/packages/excalidraw/utils.ts
@@ -1,5 +1,6 @@
 import { COLOR_PALETTE } from "./colors";
 import {
+  DEFAULT_UI_OPTIONS,
   DEFAULT_VERSION,
   EVENT,
   FONT_FAMILY,
@@ -1059,7 +1060,7 @@ let _uiMode: string | undefined = "";
 export const getUiMode = (): UIOptions["mode"] => {
   if (!_uiMode) {
     _uiMode = (new URLSearchParams(window.location.search).get("mode") ??
-      "all") as UIOptions["mode"];
+      DEFAULT_UI_OPTIONS.mode) as UIOptions["mode"];
   }
   return _uiMode as UIOptions["mode"];
 };

--- a/packages/excalidraw/utils.ts
+++ b/packages/excalidraw/utils.ts
@@ -11,6 +11,7 @@ import {
   ActiveTool,
   AppState,
   ToolType,
+  UIOptions,
   UnsubscribeCallback,
   Zoom,
 } from "./types";
@@ -1052,6 +1053,15 @@ export function getSvgPathFromStroke(points: number[][], closed = true) {
 
 export const normalizeEOL = (str: string) => {
   return str.replace(/\r?\n|\r/g, "\n");
+};
+
+let _uiMode: string | undefined = "";
+export const getUiMode = (): UIOptions["mode"] => {
+  if (!_uiMode) {
+    _uiMode = (new URLSearchParams(window.location.search).get("mode") ??
+      "all") as UIOptions["mode"];
+  }
+  return _uiMode as UIOptions["mode"];
 };
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Description

- Hide and disable all shortcuts except:
    - Delete/backspace
    - Browser built-in shortcuts for text (cut, copy, paste, undo, redo…)
- Modify behavior for delete/backspace shortcuts:
    - "delete/backspace":
        - Previous behavior: Delete selected drawing element
        - New behavior: Disabled unless currently editing text (then will behave as expected for text editing)
    - "ctrl/cmd + delete/backspace":
        - Previous behavior: Clear canvas
        - New behavior: Delete selected drawing element
- Allow running collab mode while embedded in an iFrame
- Change default zoom step amount from 10% -> 5%
- On initial load, find best fit zoom using increments of 2% zoom instead of 10%
- Remove analytics by default
- Hide footer buttons (encrypted button, help button)


## Tests performed

- All keyboard shortcuts are disabled when ui mode is not "all"
- Text editing keyboard shortcuts are always enabled and functioning
- "Delete" does not delete a drawing element when ui mode is not "all"
    - Can only delete an element using "ctrl/cmd + delete" in this case
- All keyboard shortcuts are enabled with original functionality when ui mode is "all"
- All app tests are passing