### PR TITLE
Toolbar customizations

### DIFF
--- a/packages/excalidraw/components/LaserPointerButton.tsx
+++ b/packages/excalidraw/components/LaserPointerButton.tsx
@@ -1,7 +1,7 @@
 import "./ToolIcon.scss";
 
 import clsx from "clsx";
-import { ToolButtonSize } from "./ToolButton";
+import { ToolButton } from "./ToolButton";
 import { laserPointerToolIcon } from "./icons";
 
 type LaserPointerIconProps = {
@@ -12,30 +12,18 @@ type LaserPointerIconProps = {
   isMobile?: boolean;
 };
 
-const DEFAULT_SIZE: ToolButtonSize = "small";
-
 export const LaserPointerButton = (props: LaserPointerIconProps) => {
   return (
-    <label
-      className={clsx(
-        "ToolIcon ToolIcon__LaserPointer",
-        `ToolIcon_size_${DEFAULT_SIZE}`,
-        {
-          "is-mobile": props.isMobile,
-        },
-      )}
+    <ToolButton
+      className={clsx("Shape", { fillable: false })}
+      type="radio"
+      icon={laserPointerToolIcon}
+      name="editor-current-shape"
+      checked={props.checked}
       title={`${props.title}`}
-    >
-      <input
-        className="ToolIcon_type_checkbox"
-        type="checkbox"
-        name={props.name}
-        onChange={props.onChange}
-        checked={props.checked}
-        aria-label={props.title}
-        data-testid="toolbar-LaserPointer"
-      />
-      <div className="ToolIcon__icon">{laserPointerToolIcon}</div>
-    </label>
+      aria-label={`${props.title}`}
+      data-testid={`toolbar-LaserPointer`}
+      onChange={props.onChange}
+    />
   );
 };

--- a/packages/excalidraw/components/LayerUI.tsx
+++ b/packages/excalidraw/components/LayerUI.tsx
@@ -306,28 +306,21 @@ const LayerUI = ({
                               UIOptions={UIOptions}
                               app={app}
                             />
+
+                            {isCollaborating && (
+                              <LaserPointerButton
+                                title={t("toolBar.laser")}
+                                checked={
+                                  appState.activeTool.type === TOOL_TYPE.laser
+                                }
+                                onChange={() =>
+                                  app.setActiveTool({ type: TOOL_TYPE.laser })
+                                }
+                                isMobile
+                              />
+                            )}
                           </Stack.Row>
                         </Island>
-                        {isCollaborating && (
-                          <Island
-                            style={{
-                              marginLeft: 8,
-                              alignSelf: "center",
-                              height: "fit-content",
-                            }}
-                          >
-                            <LaserPointerButton
-                              title={t("toolBar.laser")}
-                              checked={
-                                appState.activeTool.type === TOOL_TYPE.laser
-                              }
-                              onChange={() =>
-                                app.setActiveTool({ type: TOOL_TYPE.laser })
-                              }
-                              isMobile
-                            />
-                          </Island>
-                        )}
                       </Stack.Row>
                     </Stack.Col>
                   </div>

--- a/packages/excalidraw/components/LayerUI.tsx
+++ b/packages/excalidraw/components/LayerUI.tsx
@@ -245,95 +245,105 @@ const LayerUI = ({
     return (
       <FixedSideContainer side="top">
         <div className="App-menu App-menu_top">
+          {/* Left tools */}
           <Stack.Col gap={6} className={clsx("App-menu_top__left")}>
             {UIOptions.mode === "all" && renderCanvasActions()}
             {shouldRenderSelectedShapeActions && renderSelectedShapeActions()}
           </Stack.Col>
+
+          {/* Middle toolbar */}
           {!appState.viewModeEnabled && (
             <Section heading="shapes" className="shapes-section">
               {(heading: React.ReactNode) => (
-                <div style={{ position: "relative" }}>
-                  {renderWelcomeScreen && (
-                    <tunnels.WelcomeScreenToolbarHintTunnel.Out />
-                  )}
-                  <Stack.Col gap={4} align="start">
-                    <Stack.Row
-                      gap={1}
-                      className={clsx("App-toolbar-container", {
-                        "zen-mode": appState.zenModeEnabled,
-                      })}
-                    >
-                      <Island
-                        padding={1}
-                        className={clsx("App-toolbar", {
+                <>
+                  <div style={{ position: "relative" }}>
+                    {renderWelcomeScreen && (
+                      <tunnels.WelcomeScreenToolbarHintTunnel.Out />
+                    )}
+                    <Stack.Col gap={4} align="start">
+                      <Stack.Row
+                        gap={1}
+                        className={clsx("App-toolbar-container", {
                           "zen-mode": appState.zenModeEnabled,
                         })}
                       >
-                        <HintViewer
-                          appState={appState}
-                          isMobile={device.editor.isMobile}
-                          device={device}
-                          app={app}
-                        />
-                        {heading}
-                        <Stack.Row gap={1}>
-                          <PenModeButton
-                            zenModeEnabled={appState.zenModeEnabled}
-                            checked={appState.penMode}
-                            onChange={() => onPenModeToggle(null)}
-                            title={t("toolBar.penMode")}
-                            penDetected={appState.penDetected}
-                          />
-                          <LockButton
-                            checked={appState.activeTool.locked}
-                            onChange={onLockToggle}
-                            title={t("toolBar.lock")}
-                          />
-
-                          <div className="App-toolbar__divider" />
-
-                          <HandButton
-                            checked={isHandToolActive(appState)}
-                            onChange={() => onHandToolToggle()}
-                            title={t("toolBar.hand")}
-                            isMobile
-                          />
-
-                          <ShapesSwitcher
-                            appState={appState}
-                            activeTool={appState.activeTool}
-                            UIOptions={UIOptions}
-                            app={app}
-                          />
-                        </Stack.Row>
-                      </Island>
-                      {isCollaborating && (
                         <Island
-                          style={{
-                            marginLeft: 8,
-                            alignSelf: "center",
-                            height: "fit-content",
-                          }}
+                          padding={1}
+                          className={clsx("App-toolbar", {
+                            "zen-mode": appState.zenModeEnabled,
+                          })}
                         >
-                          <LaserPointerButton
-                            title={t("toolBar.laser")}
-                            checked={
-                              appState.activeTool.type === TOOL_TYPE.laser
-                            }
-                            onChange={() =>
-                              app.setActiveTool({ type: TOOL_TYPE.laser })
-                            }
-                            isMobile
-                          />
+                          {heading}
+                          <Stack.Row gap={1}>
+                            <PenModeButton
+                              zenModeEnabled={appState.zenModeEnabled}
+                              checked={appState.penMode}
+                              onChange={() => onPenModeToggle(null)}
+                              title={t("toolBar.penMode")}
+                              penDetected={appState.penDetected}
+                            />
+                            {["full", "all"].includes(UIOptions.mode!) && (
+                              <>
+                                <LockButton
+                                  checked={appState.activeTool.locked}
+                                  onChange={onLockToggle}
+                                  title={t("toolBar.lock")}
+                                />
+                                <div className="App-toolbar__divider" />
+                              </>
+                            )}
+
+                            <HandButton
+                              checked={isHandToolActive(appState)}
+                              onChange={() => onHandToolToggle()}
+                              title={t("toolBar.hand")}
+                              isMobile
+                            />
+
+                            <ShapesSwitcher
+                              appState={appState}
+                              activeTool={appState.activeTool}
+                              UIOptions={UIOptions}
+                              app={app}
+                            />
+                          </Stack.Row>
                         </Island>
-                      )}
-                    </Stack.Row>
-                  </Stack.Col>
-                </div>
+                        {isCollaborating && (
+                          <Island
+                            style={{
+                              marginLeft: 8,
+                              alignSelf: "center",
+                              height: "fit-content",
+                            }}
+                          >
+                            <LaserPointerButton
+                              title={t("toolBar.laser")}
+                              checked={
+                                appState.activeTool.type === TOOL_TYPE.laser
+                              }
+                              onChange={() =>
+                                app.setActiveTool({ type: TOOL_TYPE.laser })
+                              }
+                              isMobile
+                            />
+                          </Island>
+                        )}
+                      </Stack.Row>
+                    </Stack.Col>
+                  </div>
+                  <HintViewer
+                    appState={appState}
+                    isMobile={device.editor.isMobile}
+                    device={device}
+                    app={app}
+                  />
+                </>
               )}
             </Section>
           )}
-          {UIOptions.mode === "all" && (
+
+          {/* Right toolbar */}
+          {UIOptions.mode === "all" ? (
             <div
               className={clsx(
                 "layer-ui__wrapper__top-right zen-mode-transition",
@@ -356,6 +366,9 @@ const LayerUI = ({
                   <tunnels.DefaultSidebarTriggerTunnel.Out />
                 )}
             </div>
+          ) : (
+            // keep an element here to maintain layout styling
+            <div></div>
           )}
         </div>
       </FixedSideContainer>

--- a/packages/excalidraw/css/styles.scss
+++ b/packages/excalidraw/css/styles.scss
@@ -310,8 +310,10 @@
   }
 
   .shapes-section {
+    position: relative;
     display: flex;
     justify-content: center;
+    align-items: center;
     pointer-events: none !important;
 
     & > * {

--- a/packages/excalidraw/scene/scroll.ts
+++ b/packages/excalidraw/scene/scroll.ts
@@ -93,7 +93,8 @@ export const calculateScrollCenter = (
   let centerY = (y1 + y2) / 2;
 
   if (mode !== "none") {
-    centerY -= 20;
+    zoom = { value: getNormalizedZoom(zoom.value - 0.02) };
+    centerY -= 60;
   } else {
     centerY += 10;
   }

--- a/packages/excalidraw/shapes.tsx
+++ b/packages/excalidraw/shapes.tsx
@@ -19,6 +19,7 @@ export const SHAPES = [
     key: KEYS.V,
     numericKey: KEYS["1"],
     fillable: true,
+    modes: ["minimal", "full", "all"],
   },
   {
     icon: RectangleIcon,
@@ -26,6 +27,7 @@ export const SHAPES = [
     key: KEYS.R,
     numericKey: KEYS["2"],
     fillable: true,
+    modes: ["full", "all"],
   },
   {
     icon: DiamondIcon,
@@ -33,6 +35,7 @@ export const SHAPES = [
     key: KEYS.D,
     numericKey: KEYS["3"],
     fillable: true,
+    modes: ["full", "all"],
   },
   {
     icon: EllipseIcon,
@@ -40,6 +43,7 @@ export const SHAPES = [
     key: KEYS.O,
     numericKey: KEYS["4"],
     fillable: true,
+    modes: ["full", "all"],
   },
   {
     icon: ArrowIcon,
@@ -47,6 +51,7 @@ export const SHAPES = [
     key: KEYS.A,
     numericKey: KEYS["5"],
     fillable: true,
+    modes: ["full", "all"],
   },
   {
     icon: LineIcon,
@@ -54,6 +59,7 @@ export const SHAPES = [
     key: KEYS.L,
     numericKey: KEYS["6"],
     fillable: true,
+    modes: ["full", "all"],
   },
   {
     icon: FreedrawIcon,
@@ -61,6 +67,7 @@ export const SHAPES = [
     key: [KEYS.P, KEYS.X],
     numericKey: KEYS["7"],
     fillable: false,
+    modes: ["full", "all"],
   },
   {
     icon: TextIcon,
@@ -68,6 +75,7 @@ export const SHAPES = [
     key: KEYS.T,
     numericKey: KEYS["8"],
     fillable: false,
+    modes: ["full", "all"],
   },
   {
     icon: ImageIcon,
@@ -75,6 +83,7 @@ export const SHAPES = [
     key: null,
     numericKey: KEYS["9"],
     fillable: false,
+    modes: ["full", "all"],
   },
   {
     icon: EraserIcon,
@@ -82,6 +91,7 @@ export const SHAPES = [
     key: KEYS.E,
     numericKey: KEYS["0"],
     fillable: false,
+    modes: ["full", "all"],
   },
 ] as const;
 

--- a/packages/excalidraw/tests/scroll.test.tsx
+++ b/packages/excalidraw/tests/scroll.test.tsx
@@ -8,6 +8,7 @@ import { Excalidraw } from "../index";
 import { API } from "./helpers/api";
 import { Keyboard } from "./helpers/ui";
 import { KEYS } from "../keys";
+import { getNormalizedZoom } from "../scene";
 
 const { h } = window;
 
@@ -47,8 +48,14 @@ describe("appState", () => {
       expect(h.state.offsetTop).toBe(OFFSET_TOP);
 
       // assert scroll is in center
-      expect(h.state.scrollX).toBe(WIDTH / 2 - ELEM_WIDTH / 2);
-      // expect(h.state.scrollY).toBe(HEIGHT / 2 - ELEM_HEIGHT / 2);
+      expect(h.state.scrollX).toBe(
+        WIDTH / 2 / h.state.zoom.value - ELEM_WIDTH / 2,
+      );
+
+      // subtract 60 because offset added to make room for toolbar
+      expect(h.state.scrollY).toBe(
+        HEIGHT / 2 / h.state.zoom.value - (ELEM_HEIGHT / 2 - 60),
+      );
     });
     restoreOriginalGetBoundingClientRect();
   });


### PR DESCRIPTION
## Description

- Change what options appear in the toolbar based on ui mode:
    - "none": No tools appear
    - "minimal": Only hand, pointer, and laser appear
    - "full": All tools from the main toolbar (excludes library, share, canvas menu)
    - "all": All tools and menus appear
- Style change: move the laser pointer tool into the same toolbar box as other shapes
- Zoom change: to make room for the toolbar, zoom out an additional 2% in ui modes where toolbar is shown, and pan down 60px.

## Tests performed

- Each mode only displays the tools noted above
- The same drawing file is zoomed 2% more when mode="none" compared to all other modes that include the toolbar
- Toolbar remains centered on page, even in modes when tools are removed
    - Hint text remains centered as well, taking up all available width as if the toolbar were full.
- All app tests are passing