### PR TITLE
Pointer colors

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -68,7 +68,6 @@ import {
 import {
   getLibraryItemsFromStorage,
   importFromLocalStorage,
-  importUsernameFromLocalStorage,
 } from "./data/localStorage";
 import CustomStats from "./CustomStats";
 import {
@@ -440,7 +439,7 @@ const ExcalidrawWrapper = () => {
         // don't sync if local state is newer or identical to browser state
         if (isBrowserStorageStateNewer(STORAGE_KEYS.VERSION_DATA_STATE)) {
           const localDataState = importFromLocalStorage();
-          const username = importUsernameFromLocalStorage();
+          const username = getUsernameFromSearchParams();
           let langCode = languageDetector.detect() || defaultLang.code;
           if (Array.isArray(langCode)) {
             langCode = langCode[0];

--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -46,6 +46,7 @@ import {
   resolvablePromise,
   getUiMode,
   getUsernameFromSearchParams,
+  getUserColorFromSearchParams,
 } from "../packages/excalidraw/utils";
 import {
   FIREBASE_STORAGE_PREFIXES,
@@ -231,7 +232,9 @@ const initializeScene = async (opts: {
   if (roomLinkData && opts.collabAPI) {
     const { excalidrawAPI, collabAPI } = opts;
     const username = getUsernameFromSearchParams();
+    const userColor = getUserColorFromSearchParams();
     collabAPI.setUsername(username || "");
+    collabAPI.setUserColor(userColor || "");
 
     const scene = await collabAPI.startCollaboration(roomLinkData);
 

--- a/excalidraw-app/collab/Portal.tsx
+++ b/excalidraw-app/collab/Portal.tsx
@@ -190,6 +190,7 @@ class Portal {
           socketId: this.socket.id as SocketId,
           userState,
           username: this.collab.state.username,
+          userColor: this.collab.state.userColor,
         },
       };
       return this._broadcastSocketData(
@@ -213,6 +214,7 @@ class Portal {
           selectedElementIds:
             this.collab.excalidrawAPI.getAppState().selectedElementIds,
           username: this.collab.state.username,
+          userColor: this.collab.state.userColor,
         },
       };
 
@@ -235,6 +237,7 @@ class Portal {
         payload: {
           socketId: this.socket.id as SocketId,
           username: this.collab.state.username,
+          userColor: this.collab.state.userColor,
           sceneBounds: payload.sceneBounds,
         },
       };

--- a/excalidraw-app/data/index.ts
+++ b/excalidraw-app/data/index.ts
@@ -95,6 +95,7 @@ export type SocketUpdateDataSource = {
       button: "down" | "up";
       selectedElementIds: AppState["selectedElementIds"];
       username: string;
+      userColor: string;
     };
   };
   USER_VISIBLE_SCENE_BOUNDS: {
@@ -102,6 +103,7 @@ export type SocketUpdateDataSource = {
     payload: {
       socketId: SocketId;
       username: string;
+      userColor: string;
       sceneBounds: SceneBounds;
     };
   };
@@ -111,6 +113,7 @@ export type SocketUpdateDataSource = {
       socketId: SocketId;
       userState: UserIdleState;
       username: string;
+      userColor: string;
     };
   };
 };

--- a/excalidraw-app/data/localStorage.ts
+++ b/excalidraw-app/data/localStorage.ts
@@ -20,11 +20,37 @@ export const saveUsernameToLocalStorage = (username: string) => {
   }
 };
 
+export const saveUserColorToLocalStorage = (userColor: string) => {
+  try {
+    localStorage.setItem(
+      STORAGE_KEYS.LOCAL_STORAGE_COLLAB,
+      JSON.stringify({ userColor }),
+    );
+  } catch (error: any) {
+    // Unable to access window.localStorage
+    console.error(error);
+  }
+};
+
 export const importUsernameFromLocalStorage = (): string | null => {
   try {
     const data = localStorage.getItem(STORAGE_KEYS.LOCAL_STORAGE_COLLAB);
     if (data) {
       return JSON.parse(data).username;
+    }
+  } catch (error: any) {
+    // Unable to access localStorage
+    console.error(error);
+  }
+
+  return null;
+};
+
+export const importUserColorFromLocalStorage = (): string | null => {
+  try {
+    const data = localStorage.getItem(STORAGE_KEYS.LOCAL_STORAGE_COLLAB);
+    if (data) {
+      return JSON.parse(data).userColor;
     }
   } catch (error: any) {
     // Unable to access localStorage

--- a/excalidraw-app/data/localStorage.ts
+++ b/excalidraw-app/data/localStorage.ts
@@ -8,58 +8,6 @@ import { clearElementsForLocalStorage } from "../../packages/excalidraw/element"
 import { STORAGE_KEYS } from "../app_constants";
 import { ImportedDataState } from "../../packages/excalidraw/data/types";
 
-export const saveUsernameToLocalStorage = (username: string) => {
-  try {
-    localStorage.setItem(
-      STORAGE_KEYS.LOCAL_STORAGE_COLLAB,
-      JSON.stringify({ username }),
-    );
-  } catch (error: any) {
-    // Unable to access window.localStorage
-    console.error(error);
-  }
-};
-
-export const saveUserColorToLocalStorage = (userColor: string) => {
-  try {
-    localStorage.setItem(
-      STORAGE_KEYS.LOCAL_STORAGE_COLLAB,
-      JSON.stringify({ userColor }),
-    );
-  } catch (error: any) {
-    // Unable to access window.localStorage
-    console.error(error);
-  }
-};
-
-export const importUsernameFromLocalStorage = (): string | null => {
-  try {
-    const data = localStorage.getItem(STORAGE_KEYS.LOCAL_STORAGE_COLLAB);
-    if (data) {
-      return JSON.parse(data).username;
-    }
-  } catch (error: any) {
-    // Unable to access localStorage
-    console.error(error);
-  }
-
-  return null;
-};
-
-export const importUserColorFromLocalStorage = (): string | null => {
-  try {
-    const data = localStorage.getItem(STORAGE_KEYS.LOCAL_STORAGE_COLLAB);
-    if (data) {
-      return JSON.parse(data).userColor;
-    }
-  } catch (error: any) {
-    // Unable to access localStorage
-    console.error(error);
-  }
-
-  return null;
-};
-
 export const importFromLocalStorage = () => {
   let savedElements = null;
   let savedState = null;

--- a/packages/excalidraw/actions/actionNavigate.tsx
+++ b/packages/excalidraw/actions/actionNavigate.tsx
@@ -39,10 +39,10 @@ export const actionGoToCollaborator = register({
     };
   },
   PanelComponent: ({ updateData, data, appState }) => {
-    const { clientId, collaborator, withName, isBeingFollowed } =
+    const { collaborator, withName, isBeingFollowed } =
       data as GoToCollaboratorComponentProps;
 
-    const background = getClientColor(clientId);
+    const background = collaborator.color.background;
 
     return withName ? (
       <div

--- a/packages/excalidraw/clients.ts
+++ b/packages/excalidraw/clients.ts
@@ -23,7 +23,7 @@ export const getClientColor = (
   // words a hue value of step size 10). There are 37 such values including 0.
   const hue = (hash % 37) * 10;
   const saturation = 100;
-  const lightness = 83;
+  const lightness = 70;
 
   return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
 };

--- a/packages/excalidraw/clients.ts
+++ b/packages/excalidraw/clients.ts
@@ -23,7 +23,7 @@ export const getClientColor = (
   // words a hue value of step size 10). There are 37 such values including 0.
   const hue = (hash % 37) * 10;
   const saturation = 100;
-  const lightness = 70;
+  const lightness = 76;
 
   return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
 };

--- a/packages/excalidraw/components/UserList.tsx
+++ b/packages/excalidraw/components/UserList.tsx
@@ -82,7 +82,7 @@ const renderCollaborator = ({
 
 type UserListUserObject = Pick<
   Collaborator,
-  "avatarUrl" | "id" | "socketId" | "username"
+  "avatarUrl" | "id" | "socketId" | "username" | "color"
 >;
 
 type UserListProps = {
@@ -97,6 +97,7 @@ const collaboratorComparatorKeys = [
   "id",
   "socketId",
   "username",
+  "color",
 ] as const;
 
 export const UserList = React.memo(

--- a/packages/excalidraw/components/canvases/InteractiveCanvas.tsx
+++ b/packages/excalidraw/components/canvases/InteractiveCanvas.tsx
@@ -75,6 +75,7 @@ const InteractiveCanvas = (props: InteractiveCanvasProps) => {
       {};
     const pointerUsernames: { [id: string]: string } = {};
     const pointerUserStates: { [id: string]: string } = {};
+    const pointerUserColors: { [id: string]: string } = {};
 
     props.appState.collaborators.forEach((user, socketId) => {
       if (user.selectedElementIds) {
@@ -93,6 +94,9 @@ const InteractiveCanvas = (props: InteractiveCanvasProps) => {
       }
       if (user.userState) {
         pointerUserStates[socketId] = user.userState;
+      }
+      if (user.color) {
+        pointerUserColors[socketId] = user.color.background;
       }
       pointerViewportCoords[socketId] = sceneCoordsToViewportCoords(
         {
@@ -125,6 +129,7 @@ const InteractiveCanvas = (props: InteractiveCanvasProps) => {
           remoteSelectedElementIds,
           remotePointerUsernames: pointerUsernames,
           remotePointerUserStates: pointerUserStates,
+          remotePointerColors: pointerUserColors,
           selectionColor,
           renderScrollbars: false,
         },

--- a/packages/excalidraw/laser-trails.ts
+++ b/packages/excalidraw/laser-trails.ts
@@ -4,7 +4,6 @@ import { AnimationFrameHandler } from "./animation-frame-handler";
 import type App from "./components/App";
 import { SocketId } from "./types";
 import { easeOut } from "./utils";
-import { getClientColor } from "./clients";
 
 export class LaserTrails implements Trail {
   public localTrail: AnimatedTrail;
@@ -85,7 +84,7 @@ export class LaserTrails implements Trail {
         trail = new AnimatedTrail(this.animationFrameHandler, this.app, {
           ...this.getTrailOptions(),
           fill: () =>
-            this.app.state.collaborators.get(key)?.color.background || "red",
+            this.app.state.collaborators.get(key)?.color?.background || "red",
         });
         trail.start(this.container);
 

--- a/packages/excalidraw/laser-trails.ts
+++ b/packages/excalidraw/laser-trails.ts
@@ -78,13 +78,14 @@ export class LaserTrails implements Trail {
       return;
     }
 
-    for (const [key, collabolator] of this.app.state.collaborators.entries()) {
+    for (const [key, collaborator] of this.app.state.collaborators.entries()) {
       let trail!: AnimatedTrail;
 
       if (!this.collabTrails.has(key)) {
         trail = new AnimatedTrail(this.animationFrameHandler, this.app, {
           ...this.getTrailOptions(),
-          fill: () => getClientColor(key),
+          fill: () =>
+            this.app.state.collaborators.get(key)?.color.background || "red",
         });
         trail.start(this.container);
 
@@ -93,21 +94,21 @@ export class LaserTrails implements Trail {
         trail = this.collabTrails.get(key)!;
       }
 
-      if (collabolator.pointer && collabolator.pointer.tool === "laser") {
-        if (collabolator.button === "down" && !trail.hasCurrentTrail) {
-          trail.startPath(collabolator.pointer.x, collabolator.pointer.y);
+      if (collaborator.pointer && collaborator.pointer.tool === "laser") {
+        if (collaborator.button === "down" && !trail.hasCurrentTrail) {
+          trail.startPath(collaborator.pointer.x, collaborator.pointer.y);
         }
 
         if (
-          collabolator.button === "down" &&
+          collaborator.button === "down" &&
           trail.hasCurrentTrail &&
-          !trail.hasLastPoint(collabolator.pointer.x, collabolator.pointer.y)
+          !trail.hasLastPoint(collaborator.pointer.x, collaborator.pointer.y)
         ) {
-          trail.addPointToPath(collabolator.pointer.x, collabolator.pointer.y);
+          trail.addPointToPath(collaborator.pointer.x, collaborator.pointer.y);
         }
 
-        if (collabolator.button === "up" && trail.hasCurrentTrail) {
-          trail.addPointToPath(collabolator.pointer.x, collabolator.pointer.y);
+        if (collaborator.button === "up" && trail.hasCurrentTrail) {
+          trail.addPointToPath(collaborator.pointer.x, collaborator.pointer.y);
           trail.endPath();
         }
       }

--- a/packages/excalidraw/renderer/renderScene.ts
+++ b/packages/excalidraw/renderer/renderScene.ts
@@ -599,7 +599,7 @@ const _renderInteractiveScene = ({
           selectionColors.push(
             ...renderConfig.remoteSelectedElementIds[element.id].map(
               (socketId: string) => {
-                const background = getClientColor(socketId);
+                const background = renderConfig.remotePointerColors[socketId];
                 return background;
               },
             ),
@@ -747,7 +747,7 @@ const _renderInteractiveScene = ({
     y = Math.max(y, 0);
     y = Math.min(y, normalizedHeight - height);
 
-    const background = getClientColor(clientId);
+    const background = renderConfig.remotePointerColors[clientId];
 
     context.save();
     context.strokeStyle = background;

--- a/packages/excalidraw/scene/types.ts
+++ b/packages/excalidraw/scene/types.ts
@@ -50,6 +50,7 @@ export type InteractiveCanvasRenderConfig = {
   remotePointerViewportCoords: { [id: string]: { x: number; y: number } };
   remotePointerUserStates: { [id: string]: string };
   remotePointerUsernames: { [id: string]: string };
+  remotePointerColors: { [id: string]: string };
   remotePointerButton?: { [id: string]: string | undefined };
   selectionColor?: string;
   // extra options passed to the renderer

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -50,7 +50,7 @@ export type Collaborator = Readonly<{
   selectedElementIds?: AppState["selectedElementIds"];
   username?: string | null;
   userState?: UserIdleState;
-  color?: {
+  color: {
     background: string;
     stroke: string;
   };

--- a/packages/excalidraw/utils.ts
+++ b/packages/excalidraw/utils.ts
@@ -1069,6 +1069,10 @@ export const getUsernameFromSearchParams = (): string | null => {
   return new URLSearchParams(window.location.search).get("name");
 };
 
+export const getUserColorFromSearchParams = (): string | null => {
+  return new URLSearchParams(window.location.search).get("color");
+};
+
 // -----------------------------------------------------------------------------
 type HasBrand<T> = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/excalidraw/utils.ts
+++ b/packages/excalidraw/utils.ts
@@ -1,3 +1,4 @@
+import { getRandomUsername } from "@excalidraw/random-username";
 import { COLOR_PALETTE } from "./colors";
 import {
   DEFAULT_UI_OPTIONS,
@@ -17,6 +18,7 @@ import {
   Zoom,
 } from "./types";
 import { ResolutionType } from "./utility-types";
+import { getClientColor } from "./clients";
 
 let mockDateTime: string | null = null;
 
@@ -1065,12 +1067,27 @@ export const getUiMode = (): UIOptions["mode"] => {
   return _uiMode as UIOptions["mode"];
 };
 
-export const getUsernameFromSearchParams = (): string | null => {
-  return new URLSearchParams(window.location.search).get("name");
+let _username: string = "";
+export const getUsernameFromSearchParams = (): string => {
+  if (!_username) {
+    _username =
+      new URLSearchParams(window.location.search).get("name") ??
+      getRandomUsername();
+  }
+  return _username;
 };
 
-export const getUserColorFromSearchParams = (): string | null => {
-  return new URLSearchParams(window.location.search).get("color");
+let _userColor: string = "";
+export const getUserColorFromSearchParams = (id?: string): string => {
+  if (!_userColor) {
+    const param = new URLSearchParams(window.location.search).get("color");
+    if (param) {
+      _userColor = param;
+    } else if (id) {
+      _userColor = getClientColor(id);
+    }
+  }
+  return _userColor;
 };
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Description

If a color is not provided in the URL, generate a color based on some unique id - this id should be the socket id if one exists, but the username is used as a fallback. However, when collab mode is on, the socket id should always exist as long as the connection was established successfully. This way even people with the same username should have a unique color.

If a color is provided in the URL, use that color instead of generating one.

This PR also removed using local storage for usernames (and as such, colors is not using local storage either) - this is so that if a user views a drawing first with no name/color in the URL bar and a random one is assigned to them, that value is not pulled from local storage when now that user DOES have a name/color in the URL bar.
- The downside of this is that refreshing as an anonymous user will not keep your same auto-generated name, which is a regression. For our use case, the name should always be provided and therefore be consistent.
- The color will also not be consistent, but this is not a regression. 

## Tests Performed
- No color in the url bar uses a generated color
    - The generated color is unique, even if the user names are the same.
- Color in the url bar is always used when provided
- Visiting a url with no name param, followed by a url with a name, uses the given name instead of pulling the old random name.