### PR TITLE
Do not set errored files on 403

### DIFF
--- a/excalidraw-app/data/httpStorage.ts
+++ b/excalidraw-app/data/httpStorage.ts
@@ -208,6 +208,10 @@ export const loadFilesFromHttpStorage = async (
             // TODO (Jess): consider adding:
             // lastRetrieved: metadata?.created || Date.now(),
           });
+        } else if (response.status === 403) {
+          // Note that we don't consider this an "erroredFile" because we still want
+          // other connected clients to be able to load the file
+          console.error("File access forbidden", id);
         } else {
           erroredFiles.set(id, true);
         }


### PR DESCRIPTION
## Description

By not marking the 403 file load as "error", we will ensure that other clients will continue to try to load the file data.

## Tests Performed

- Loaded in 2 tabs as authorized and unauthorized viewer, and drawing file was not corrupted.
- All tests are passing