### PR TITLE
Hide pretzel message, replace with posthog log instead

### DIFF
--- a/excalidraw-app/collab/Collab.tsx
+++ b/excalidraw-app/collab/Collab.tsx
@@ -451,7 +451,10 @@ class Collab extends PureComponent<CollabProps, CollabState> {
     );
 
     const fallbackInitializationHandler = () => {
-      console.log("[draw] Fallback initialization handler", existingRoomLinkData);
+      console.log(
+        "[draw] Fallback initialization handler",
+        existingRoomLinkData,
+      );
       this.initializeRoom({
         roomLinkData: existingRoomLinkData,
         fetchScene: true,

--- a/excalidraw-app/components/PostHogProvider.tsx
+++ b/excalidraw-app/components/PostHogProvider.tsx
@@ -1,0 +1,27 @@
+import { PostHogProvider } from "posthog-js/react";
+
+interface PostHogProviderWrapperProps {
+  children: React.ReactNode;
+}
+
+const PostHogProviderWrapper: React.FC<PostHogProviderWrapperProps> = ({
+  children,
+}: PostHogProviderWrapperProps) => {
+  const apiKey = import.meta.env.VITE_PUBLIC_POSTHOG_KEY;
+  const options = {
+    api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+    session_recording: {
+      recordCrossOriginIframes: true,
+    },
+  };
+  if (!apiKey || !options.api_host) {
+    return <>{children}</>;
+  }
+  return (
+    <PostHogProvider apiKey={apiKey} options={options}>
+      {children}
+    </PostHogProvider>
+  );
+};
+
+export default PostHogProviderWrapper;

--- a/excalidraw-app/components/PostHogProvider.tsx
+++ b/excalidraw-app/components/PostHogProvider.tsx
@@ -7,9 +7,9 @@ interface PostHogProviderWrapperProps {
 const PostHogProviderWrapper: React.FC<PostHogProviderWrapperProps> = ({
   children,
 }: PostHogProviderWrapperProps) => {
-  const apiKey = import.meta.env.VITE_PUBLIC_POSTHOG_KEY;
+  const apiKey = import.meta.env.VITE_APP_POSTHOG_KEY;
   const options = {
-    api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+    api_host: import.meta.env.VITE_APP_POSTHOG_HOST,
     session_recording: {
       recordCrossOriginIframes: true,
     },

--- a/excalidraw-app/index.html
+++ b/excalidraw-app/index.html
@@ -187,14 +187,6 @@
         }
       }
     </style>
-
-    <script>
-      !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-      posthog.init('phc_UAuvxocW0Fuy0nzVFKEMErd3CjBfzLpwY3MBgUHVI41',{
-        api_host:'https://ph.sparkwise.co',
-        session_recording: { recordCrossOriginIframes: true },
-      })
-    </script>
   </head>
 
   <body>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "i18next-browser-languagedetector": "6.1.4",
     "idb-keyval": "6.0.3",
     "jotai": "1.13.1",
+    "posthog-js": "1.116.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "socket.io-client": "4.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6256,6 +6256,11 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+fflate@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.4.8.tgz#f90b82aefbd8ac174213abb338bd7ef848f0f5ae"
+  integrity sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==
+
 fflate@^0.7.4:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.7.4.tgz#61587e5d958fdabb5a9368a302c25363f4f69f50"
@@ -8575,6 +8580,19 @@ postcss@^8.4.32, postcss@^8.4.7:
     nanoid "^3.3.7"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+posthog-js@1.116.6:
+  version "1.116.6"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.116.6.tgz#9a5c9f49230a76642f4c44d93b96710f886c2880"
+  integrity sha512-rvt8HxzJD4c2B/xsUa4jle8ApdqljeBI2Qqjp4XJMohQf18DXRyM6b96H5/UMs8jxYuZG14Er0h/kEIWeU6Fmw==
+  dependencies:
+    fflate "^0.4.8"
+    preact "^10.19.3"
+
+preact@^10.19.3:
+  version "10.20.1"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.20.1.tgz#1bc598ab630d8612978f7533da45809a8298542b"
+  integrity sha512-JIFjgFg9B2qnOoGiYMVBtrcFxHqn+dNXbq76bVmcaHYJFYR4lW67AOcXgAYQQTDYXDOg/kTZrKPNCdRgJ2UJmw==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Description

Our specialized use case of Excalidraw means we should never be self-embedding, so we want to go ahead and render the app instead of showing the warning message "I'm not a pretzel". Instead, we'll add a posthog log there so we know how frequently this case may be happening.

## Tests Performed

- When there is no posthog key/host, the posthog provider does not render but the rest of the app works as expected.
- Posthog provider renders when key/host is provided.
- All tests are passing