### PR TITLE
Move hint text above toolbar, adjust view

### DIFF
--- a/packages/excalidraw/actions/actionCanvas.tsx
+++ b/packages/excalidraw/actions/actionCanvas.tsx
@@ -10,7 +10,7 @@ import { getNormalizedZoom } from "../scene";
 import { centerScrollOn } from "../scene/scroll";
 import { getStateForZoom } from "../scene/zoom";
 import { AppState, NormalizedZoomValue } from "../types";
-import { getShortcutKey, updateActiveTool } from "../utils";
+import { getShortcutKey, getUiMode, updateActiveTool } from "../utils";
 import { register } from "./register";
 import { Tooltip } from "../components/Tooltip";
 import { newElementWith } from "../element/mutateElement";
@@ -117,7 +117,7 @@ export const actionZoomIn = register({
   PanelComponent: ({ updateData }) => (
     <ToolButton
       type="button"
-      className="zoom-in-button zoom-button"
+      className={`zoom-in-button zoom-button ui-mode-${getUiMode()}`}
       icon={ZoomInIcon}
       title={`${t("buttons.zoomIn")} — ${getShortcutKey("CtrlOrCmd++")}`}
       aria-label={t("buttons.zoomIn")}
@@ -155,7 +155,7 @@ export const actionZoomOut = register({
   PanelComponent: ({ updateData }) => (
     <ToolButton
       type="button"
-      className="zoom-out-button zoom-button"
+      className={`zoom-out-button zoom-button ui-mode-${getUiMode()}`}
       icon={ZoomOutIcon}
       title={`${t("buttons.zoomOut")} — ${getShortcutKey("CtrlOrCmd+-")}`}
       aria-label={t("buttons.zoomOut")}
@@ -194,7 +194,7 @@ export const actionResetZoom = register({
     <Tooltip label={t("buttons.resetZoom")} style={{ height: "100%" }}>
       <ToolButton
         type="button"
-        className="reset-zoom-button zoom-button"
+        className={`reset-zoom-button zoom-button ui-mode-${getUiMode()}`}
         title={t("buttons.resetZoom")}
         aria-label={t("buttons.resetZoom")}
         onClick={() => {

--- a/packages/excalidraw/components/Actions.scss
+++ b/packages/excalidraw/components/Actions.scss
@@ -10,11 +10,21 @@
   border-radius: 0 !important;
   background-color: var(--sparkwise-color-gray-100) !important;
   font-size: 0.875rem !important;
-  width: var(--lg-button-size);
-  height: var(--lg-button-size);
+
+  width: var(--md-button-size);
+  height: var(--md-button-size);
   svg {
-    width: var(--lg-icon-size) !important;
-    height: var(--lg-icon-size) !important;
+    width: var(--md-icon-size) !important;
+    height: var(--md-icon-size) !important;
+  }
+
+  &.ui-mode-all {
+    width: var(--lg-button-size);
+    height: var(--lg-button-size);
+    svg {
+      width: var(--lg-icon-size) !important;
+      height: var(--lg-icon-size) !important;
+    }
   }
 
   .ToolIcon__icon {

--- a/packages/excalidraw/components/FixedSideContainer.scss
+++ b/packages/excalidraw/components/FixedSideContainer.scss
@@ -11,11 +11,18 @@
   }
 
   .FixedSideContainer_side_top {
-    left: var(--editor-container-padding);
-    top: var(--editor-container-padding);
-    right: var(--editor-container-padding);
-    bottom: var(--editor-container-padding);
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
     z-index: 2;
+
+    &.ui-mode-all {
+      left: var(--editor-container-padding);
+      top: var(--editor-container-padding);
+      right: var(--editor-container-padding);
+      bottom: var(--editor-container-padding);
+    }
   }
 
   .FixedSideContainer_side_top.zen-mode {

--- a/packages/excalidraw/components/FixedSideContainer.tsx
+++ b/packages/excalidraw/components/FixedSideContainer.tsx
@@ -2,6 +2,7 @@ import "./FixedSideContainer.scss";
 
 import React from "react";
 import clsx from "clsx";
+import { getUiMode } from "../utils";
 
 type FixedSideContainerProps = {
   children: React.ReactNode;
@@ -13,14 +14,18 @@ export const FixedSideContainer = ({
   children,
   side,
   className,
-}: FixedSideContainerProps) => (
-  <div
-    className={clsx(
-      "FixedSideContainer",
-      `FixedSideContainer_side_${side}`,
-      className,
-    )}
-  >
-    {children}
-  </div>
-);
+}: FixedSideContainerProps) => {
+  const uiMode = getUiMode();
+  return (
+    <div
+      className={clsx(
+        "FixedSideContainer",
+        `FixedSideContainer_side_${side}`,
+        className,
+        { "ui-mode-all": uiMode === "all" },
+      )}
+    >
+      {children}
+    </div>
+  );
+};

--- a/packages/excalidraw/components/HintViewer.scss
+++ b/packages/excalidraw/components/HintViewer.scss
@@ -7,7 +7,7 @@ $wide-viewport-width: 1000px;
   .HintViewer {
     pointer-events: none;
     box-sizing: border-box;
-    position: absolute;
+    position: relative;
     display: flex;
     justify-content: center;
     left: 0;
@@ -18,6 +18,10 @@ $wide-viewport-width: 1000px;
     text-align: center;
     color: var(--color-gray-40);
     font-size: 0.75rem;
+
+    &.ui-mode-all {
+      position: absolute;
+    }
 
     @include isMobile {
       position: static;

--- a/packages/excalidraw/components/HintViewer.scss
+++ b/packages/excalidraw/components/HintViewer.scss
@@ -14,13 +14,13 @@ $wide-viewport-width: 1000px;
     top: 100%;
     max-width: 100%;
     width: 100%;
-    margin-top: 0.5rem;
     text-align: center;
     color: var(--color-gray-40);
     font-size: 0.75rem;
 
     &.ui-mode-all {
       position: absolute;
+      margin-top: 0.5rem;
     }
 
     @include isMobile {

--- a/packages/excalidraw/components/HintViewer.tsx
+++ b/packages/excalidraw/components/HintViewer.tsx
@@ -6,10 +6,11 @@ import {
   isTextBindableContainer,
   isTextElement,
 } from "../element/typeChecks";
-import { getShortcutKey } from "../utils";
+import { getShortcutKey, getUiMode } from "../utils";
 import { isEraserActive } from "../appState";
 
 import "./HintViewer.scss";
+import clsx from "clsx";
 
 interface HintViewerProps {
   appState: UIAppState;
@@ -136,9 +137,10 @@ export const HintViewer = ({
   }
 
   hint = getShortcutKey(hint);
+  const uiMode = getUiMode();
 
   return (
-    <div className="HintViewer">
+    <div className={clsx("HintViewer", { "ui-mode-all": uiMode === "all" })}>
       <span>{hint}</span>
     </div>
   );

--- a/packages/excalidraw/components/LayerUI.tsx
+++ b/packages/excalidraw/components/LayerUI.tsx
@@ -256,6 +256,12 @@ const LayerUI = ({
             <Section heading="shapes" className="shapes-section">
               {(heading: React.ReactNode) => (
                 <>
+                  <HintViewer
+                    appState={appState}
+                    isMobile={device.editor.isMobile}
+                    device={device}
+                    app={app}
+                  />
                   <div style={{ position: "relative" }}>
                     {renderWelcomeScreen && (
                       <tunnels.WelcomeScreenToolbarHintTunnel.Out />
@@ -324,12 +330,6 @@ const LayerUI = ({
                       </Stack.Row>
                     </Stack.Col>
                   </div>
-                  <HintViewer
-                    appState={appState}
-                    isMobile={device.editor.isMobile}
-                    device={device}
-                    app={app}
-                  />
                 </>
               )}
             </Section>

--- a/packages/excalidraw/components/footer/Footer.tsx
+++ b/packages/excalidraw/components/footer/Footer.tsx
@@ -36,7 +36,12 @@ const Footer = ({
   return (
     <footer
       role="contentinfo"
-      className="layer-ui__wrapper__footer App-menu App-menu_bottom"
+      className={clsx(
+        "layer-ui__wrapper__footer",
+        "App-menu",
+        "App-menu_bottom",
+        { "ui-mode-all": uiMode === "all" },
+      )}
     >
       <div
         className={clsx("layer-ui__wrapper__footer-left zen-mode-transition", {

--- a/packages/excalidraw/css/styles.scss
+++ b/packages/excalidraw/css/styles.scss
@@ -315,6 +315,7 @@
   .shapes-section {
     position: relative;
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
     pointer-events: none !important;

--- a/packages/excalidraw/css/styles.scss
+++ b/packages/excalidraw/css/styles.scss
@@ -352,15 +352,19 @@
 
   .App-menu_bottom {
     position: absolute;
-    bottom: 1rem;
+    bottom: 0.5rem;
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
     cursor: default;
     pointer-events: none !important;
     box-sizing: border-box;
-    padding: 0 1rem;
+    padding: 0 0.5rem;
 
+    &.ui-mode-all {
+      bottom: 1rem;
+      padding: 0 1rem;
+    }
     &--transition-left {
       section {
         width: 185px;

--- a/packages/excalidraw/css/theme.scss
+++ b/packages/excalidraw/css/theme.scss
@@ -41,6 +41,8 @@
   --default-icon-size: 1rem;
   --lg-button-size: 2.25rem;
   --lg-icon-size: 1rem;
+  --md-button-size: 2rem;
+  --md-icon-size: 1rem;
   --editor-container-padding: 1rem;
 
   @media screen and (min-device-width: 1921px) {

--- a/packages/excalidraw/scene/scroll.ts
+++ b/packages/excalidraw/scene/scroll.ts
@@ -93,8 +93,8 @@ export const calculateScrollCenter = (
   let centerY = (y1 + y2) / 2;
 
   if (mode !== "none") {
-    zoom = { value: getNormalizedZoom(zoom.value - 0.02) };
-    centerY -= 60;
+    zoom = { value: getNormalizedZoom(zoom.value - 0.04) };
+    centerY -= 30;
   } else {
     centerY += 10;
   }

--- a/packages/excalidraw/tests/scroll.test.tsx
+++ b/packages/excalidraw/tests/scroll.test.tsx
@@ -54,7 +54,7 @@ describe("appState", () => {
 
       // subtract 60 because offset added to make room for toolbar
       expect(h.state.scrollY).toBe(
-        HEIGHT / 2 / h.state.zoom.value - (ELEM_HEIGHT / 2 - 60),
+        HEIGHT / 2 / h.state.zoom.value - (ELEM_HEIGHT / 2 - 30),
       );
     });
     restoreOriginalGetBoundingClientRect();


### PR DESCRIPTION
## Description

Excluding ui mode "all", the following changes are made:
- Move the hint text above the toolbar
- Reduce the margins around the canvas so the toolbar and undo/redo buttons are closer to the edge
- Slightly reduce the size of the undo/redo and zoom buttons

I also noticed that sometimes the drawing content was getting pushed too far off screen so I adjusted the zoom/y-offset slightly as well.

## Tests Performed

- In view modes "minimal" and "full":
    - The hint text appears above the toolbar
    - The undo/redo and zoom buttons are slightly smaller
    - The spacing around the canvas is reduced
- View mode "all" is unchanged
- All tests are passing