### PR TITLE
Capture in Sentry when scene init from socket with empty elements

### DIFF
--- a/excalidraw-app/collab/Collab.tsx
+++ b/excalidraw-app/collab/Collab.tsx
@@ -533,6 +533,15 @@ class Collab extends PureComponent<CollabProps, CollabState> {
               this.handleRemoteSceneUpdate(reconciledElements, {
                 init: true,
               });
+              if (reconciledElements.length === 0) {
+                console.log("[draw] Received empty scene from socket payload");
+                Sentry.captureMessage(
+                  "Received empty scene from socket payload",
+                  {
+                    level: Sentry.Severity.Warning,
+                  },
+                );
+              }
               // noop if already resolved via init from firebase
               scenePromise.resolve({
                 elements: reconciledElements,


### PR DESCRIPTION
## Description

Another place where a user's canvas could be initialized as empty is when they receive empty data (no elements) from another user in the room via sockets. The scene should not be empty, so if this happens, capture the event in Sentry.

## Tests performed

- Receiving empty element init data via websockets triggers the log
- The log is not triggered when the websocket init data contains elements
- All tests are passing