### PR TITLE
Maintain spacing/position even when help text is empty

### DIFF
--- a/packages/excalidraw/components/HintViewer.scss
+++ b/packages/excalidraw/components/HintViewer.scss
@@ -29,6 +29,7 @@ $wide-viewport-width: 1000px;
     }
 
     > span {
+      height: 1rem;
       padding: 0.25rem;
     }
   }

--- a/packages/excalidraw/components/HintViewer.tsx
+++ b/packages/excalidraw/components/HintViewer.tsx
@@ -133,10 +133,11 @@ export const HintViewer = ({
     app,
   });
   if (!hint) {
-    return null;
+    hint = "";
+  } else {
+    hint = getShortcutKey(hint);
   }
 
-  hint = getShortcutKey(hint);
   const uiMode = getUiMode();
 
   return (


### PR DESCRIPTION
## Description

Assumes 1rem of space is enough needed to show help text. Even when there is no text, the spacing is maintained so the toolbar doesn't "jump" to the top of the screen.

## Tests Performed

- Help text area remains same size even when there is no text, and even at different browser zoom levels.
- Known issue: if help text wraps to more than 1 line, it will get covered by the toolbar. This happens at extremely small window sizes with long help text, so it should not be an issue.
- All tests passing

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206928368208155