### PR TITLE
add resolution to node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "release:excalidraw": "node scripts/release.js"
   },
   "resolutions": {
-    "@babel/traverse": ">=7.23.2"
+    "@babel/traverse": ">=7.23.2",
+    "node-fetch": "2.6.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8188,12 +8188,7 @@ next@14.1:
     "@next/swc-win32-ia32-msvc" "14.1.0"
     "@next/swc-win32-x64-msvc" "14.1.0"
 
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
-node-fetch@2.6.7:
+node-fetch@2.6.1, node-fetch@2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==


### PR DESCRIPTION
## Description

Sets a resolution for node-fetch used by the firebase dependency. This seems safer, than updating firebase itself. Not sure why the original excalidraw repo doesn't have this dependabot alert altough they are on the vulnerable node-fetch version.

https://github.com/peoplerenaissance/sparkwise-excalidraw/security/dependabot/16 

## Type of change

- Security fix (non-breaking change that fixes a potential vulnerability)

## Testing Checklist
- [x] All pre-merge tests under "Tests" performed prior to merging.
- [x] All security issues identified during the review process have been remediated.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206963304667086