### PR TITLE
Fix broken font URLs in SVG exports due to incorrect environment variable reference (#92)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ coverage
 dev-dist
 html
 examples/**/bundle.*
+CLAUDE.md 
+settings.local.json

--- a/packages/excalidraw/scene/export.ts
+++ b/packages/excalidraw/scene/export.ts
@@ -371,13 +371,13 @@ export const exportToSvg = async (
     svgRoot.setAttribute("filter", THEME_FILTER);
   }
 
-  let assetPath = "https://draw-next.sparkwise.co/";
+  let assetPath = "https://draw-prod.sparkwise.co/";
   // Asset path needs to be determined only when using package
   if (import.meta.env.VITE_IS_EXCALIDRAW_NPM_PACKAGE) {
     assetPath =
       window.EXCALIDRAW_ASSET_PATH ||
       `https://unpkg.com/${import.meta.env.VITE_PKG_NAME}@${
-        import.meta.env.PKG_VERSION
+        import.meta.env.VITE_PKG_VERSION
       }`;
 
     if (assetPath?.startsWith("/")) {

--- a/packages/excalidraw/tests/__snapshots__/export.test.tsx.snap
+++ b/packages/excalidraw/tests/__snapshots__/export.test.tsx.snap
@@ -8,17 +8,17 @@ exports[`export > exporting svg containing transformed images > svg export outpu
     <style class="style-fonts">
       @font-face {
         font-family: "Cascadia";
-        src: url("https://draw-next.sparkwise.co/Cascadia.woff2");
+        src: url("https://draw-prod.sparkwise.co/fonts/Cascadia.woff2");
       }
       @font-face {
         font-family: "ProximaNova";
-        src: url("https://draw-next.sparkwise.co/ProximaNova-Regular.woff2");
+        src: url("https://draw-prod.sparkwise.co/fonts/ProximaNova-Regular.woff2");
         font-weight: 400;
         font-display: swap;
       }
       @font-face {
         font-family: "ProximaNova";
-        src: url("https://draw-next.sparkwise.co/ProximaNova-SemiBold.woff2");
+        src: url("https://draw-prod.sparkwise.co/fonts/ProximaNova-SemiBold.woff2");
         font-weight: 600;
         font-display: swap;
       }

--- a/packages/excalidraw/tests/scene/__snapshots__/export.test.ts.snap
+++ b/packages/excalidraw/tests/scene/__snapshots__/export.test.ts.snap
@@ -23,17 +23,17 @@ exports[`exportToSvg > with default arguments 1`] = `
       
       @font-face {
         font-family: "Cascadia";
-        src: url("https://draw-next.sparkwise.co/Cascadia.woff2");
+        src: url("https://draw-prod.sparkwise.co/fonts/Cascadia.woff2");
       }
       @font-face {
         font-family: "ProximaNova";
-        src: url("https://draw-next.sparkwise.co/ProximaNova-Regular.woff2");
+        src: url("https://draw-prod.sparkwise.co/fonts/ProximaNova-Regular.woff2");
         font-weight: 400;
         font-display: swap;
       }
       @font-face {
         font-family: "ProximaNova";
-        src: url("https://draw-next.sparkwise.co/ProximaNova-SemiBold.woff2");
+        src: url("https://draw-prod.sparkwise.co/fonts/ProximaNova-SemiBold.woff2");
         font-weight: 600;
         font-display: swap;
       }
@@ -92,17 +92,17 @@ exports[`exportToSvg > with elements that have a link 1`] = `
     <style class="style-fonts">
       @font-face {
         font-family: "Cascadia";
-        src: url("https://draw-next.sparkwise.co/Cascadia.woff2");
+        src: url("https://draw-prod.sparkwise.co/Cascadia.woff2");
       }
       @font-face {
         font-family: "ProximaNova";
-        src: url("https://draw-next.sparkwise.co/ProximaNova-Regular.woff2");
+        src: url("https://draw-prod.sparkwise.co/ProximaNova-Regular.woff2");
         font-weight: 400;
         font-display: swap;
       }
       @font-face {
         font-family: "ProximaNova";
-        src: url("https://draw-next.sparkwise.co/ProximaNova-SemiBold.woff2");
+        src: url("https://draw-prod.sparkwise.co/ProximaNova-SemiBold.woff2");
         font-weight: 600;
         font-display: swap;
       }
@@ -120,17 +120,17 @@ exports[`exportToSvg > with exportEmbedScene 1`] = `
     <style class="style-fonts">
       @font-face {
         font-family: "Cascadia";
-        src: url("https://draw-next.sparkwise.co/Cascadia.woff2");
+        src: url("https://draw-prod.sparkwise.co/Cascadia.woff2");
       }
       @font-face {
         font-family: "ProximaNova";
-        src: url("https://draw-next.sparkwise.co/ProximaNova-Regular.woff2");
+        src: url("https://draw-prod.sparkwise.co/ProximaNova-Regular.woff2");
         font-weight: 400;
         font-display: swap;
       }
       @font-face {
         font-family: "ProximaNova";
-        src: url("https://draw-next.sparkwise.co/ProximaNova-SemiBold.woff2");
+        src: url("https://draw-prod.sparkwise.co/ProximaNova-SemiBold.woff2");
         font-weight: 600;
         font-display: swap;
       }


### PR DESCRIPTION

* Fix broken font URLs in SVG exports due to incorrect environment variable reference
* Fix font paths

## Description

Release

## Type of change

- Bug fix (non-breaking change that fixes an issue)

## Testing Checklist

- [X] All pre-merge tests under "Tests" performed prior to merging.
- [X] All security issues identified during the review process have been remediated.
