### PR TITLE
feat: add reconciliation to HTTP storage saves

### DIFF
--- a/excalidraw-app/collab/Collab.tsx
+++ b/excalidraw-app/collab/Collab.tsx
@@ -302,12 +302,12 @@ class Collab extends PureComponent<CollabProps, CollabState> {
         savedData.saved &&
         savedData.reconciledElements
       ) {
-        this.handleRemoteSceneUpdate(
-          this.reconcileElements(savedData.reconciledElements),
+        this.setLastBroadcastedOrReceivedSceneVersion(
+          getSceneVersion(savedData.reconciledElements),
         );
+        this.handleRemoteSceneUpdate(savedData.reconciledElements);
       }
     } catch (error: any) {
-      // firestore doesn't return a specific error code when size exceeded
       const sizeExceeded = /is longer than.*?bytes/.test(error.message);
       this.setState({
         errorMessage: sizeExceeded

--- a/excalidraw-app/collab/Collab.tsx
+++ b/excalidraw-app/collab/Collab.tsx
@@ -280,13 +280,13 @@ class Collab extends PureComponent<CollabProps, CollabState> {
     ) {
       // this won't run in time if user decides to leave the site, but
       //  the purpose is to run in immediately after user decides to stay
-      this.saveCollabRoomToFirebase(syncableElements);
+      this.saveCollabRoomToHttpStorage(syncableElements);
 
       preventUnload(event);
     }
   });
 
-  saveCollabRoomToFirebase = async (
+  saveCollabRoomToHttpStorage = async (
     syncableElements: readonly SyncableExcalidrawElement[],
   ) => {
     try {
@@ -325,10 +325,10 @@ class Collab extends PureComponent<CollabProps, CollabState> {
 
   stopCollaboration = (keepRemoteState = true) => {
     this.queueBroadcastAllElements.cancel();
-    this.queueSaveToFirebase.cancel();
+    this.queueSaveToHttpStorage.cancel();
     this.loadImageFiles.cancel();
 
-    this.saveCollabRoomToFirebase(
+    this.saveCollabRoomToHttpStorage(
       getSyncableElements(
         this.excalidrawAPI.getSceneElementsIncludingDeleted(),
       ),
@@ -519,7 +519,7 @@ class Collab extends PureComponent<CollabProps, CollabState> {
         commitToHistory: true,
       });
 
-      this.saveCollabRoomToFirebase(getSyncableElements(elements));
+      this.saveCollabRoomToHttpStorage(getSyncableElements(elements));
     }
 
     // fallback in case you're not alone in the room but still don't receive
@@ -949,7 +949,7 @@ class Collab extends PureComponent<CollabProps, CollabState> {
 
   syncElements = (elements: readonly ExcalidrawElement[]) => {
     this.broadcastElements(elements);
-    this.queueSaveToFirebase();
+    this.queueSaveToHttpStorage();
   };
 
   queueBroadcastAllElements = throttle(() => {
@@ -966,10 +966,10 @@ class Collab extends PureComponent<CollabProps, CollabState> {
     this.setLastBroadcastedOrReceivedSceneVersion(newVersion);
   }, SYNC_FULL_SCENE_INTERVAL_MS);
 
-  queueSaveToFirebase = throttle(
+  queueSaveToHttpStorage = throttle(
     () => {
       if (this.portal.socketInitialized) {
-        this.saveCollabRoomToFirebase(
+        this.saveCollabRoomToHttpStorage(
           getSyncableElements(
             this.excalidrawAPI.getSceneElementsIncludingDeleted(),
           ),

--- a/excalidraw-app/collab/Collab.tsx
+++ b/excalidraw-app/collab/Collab.tsx
@@ -286,25 +286,26 @@ class Collab extends PureComponent<CollabProps, CollabState> {
     }
   });
 
-  // TODO (Jess): consider renaming to "saveCollabRoomToHttpStorage"
   saveCollabRoomToFirebase = async (
     syncableElements: readonly SyncableExcalidrawElement[],
   ) => {
     try {
-      // TODO (Jess): Firebase uses app state when saving, consider if we should use this too
-      await saveToHttpStorage(
+      const savedData = await saveToHttpStorage(
         this.portal,
         syncableElements,
         this.tokenService,
-        // this.excalidrawAPI.getAppState(),
+        this.excalidrawAPI.getAppState(),
       );
 
-      // TODO (Jess): current httpStorage does not use reconciliation, but consider if this should be included
-      // if (this.isCollaborating() && savedData && savedData.reconciledElements) {
-      //   this.handleRemoteSceneUpdate(
-      //     this.reconcileElements(savedData.reconciledElements),
-      //   );
-      // }
+      if (
+        this.isCollaborating() &&
+        savedData.saved &&
+        savedData.reconciledElements
+      ) {
+        this.handleRemoteSceneUpdate(
+          this.reconcileElements(savedData.reconciledElements),
+        );
+      }
     } catch (error: any) {
       // firestore doesn't return a specific error code when size exceeded
       const sizeExceeded = /is longer than.*?bytes/.test(error.message);

--- a/excalidraw-app/data/httpStorage.ts
+++ b/excalidraw-app/data/httpStorage.ts
@@ -246,7 +246,11 @@ export const saveToHttpStorage = async (
   if (getResponse.ok) {
     const existingElements = await getSyncableElementsFromResponse(getResponse);
 
-    if (existingElements && existingElements.length > 0) {
+    if (
+      existingElements &&
+      existingElements.length > 0 &&
+      getSceneVersion(existingElements) !== getSceneVersion(elements)
+    ) {
       reconciledElements = reconcileElements(
         elements,
         existingElements,
@@ -258,9 +262,9 @@ export const saveToHttpStorage = async (
 
   const versionToWrite = getSceneVersion(elementsToWrite);
 
-  // If reconciled version matches cache, nothing new to save
+  // If version matches cache, nothing new to save
   if (httpStorageSceneVersionCache.get(socket) === versionToWrite) {
-    return { saved: true, reconciledElements };
+    return { saved: true, reconciledElements: null };
   }
 
   console.info("[draw] Saving drawing data...");

--- a/excalidraw-app/data/httpStorage.ts
+++ b/excalidraw-app/data/httpStorage.ts
@@ -246,11 +246,7 @@ export const saveToHttpStorage = async (
   if (getResponse.ok) {
     const existingElements = await getSyncableElementsFromResponse(getResponse);
 
-    if (
-      existingElements &&
-      existingElements.length > 0 &&
-      getSceneVersion(existingElements) !== getSceneVersion(elements)
-    ) {
+    if (existingElements && existingElements.length > 0) {
       reconciledElements = reconcileElements(
         elements,
         existingElements,

--- a/excalidraw-app/data/httpStorage.ts
+++ b/excalidraw-app/data/httpStorage.ts
@@ -6,6 +6,7 @@ import {
   restoreElements,
 } from "../../packages/excalidraw";
 import {
+  AppState,
   BinaryFileData,
   BinaryFileMetadata,
   DataURL,
@@ -16,7 +17,15 @@ import {
 } from "../../packages/excalidraw/element/types";
 import { decompressData } from "../../packages/excalidraw/data/encode";
 import Portal from "../collab/Portal";
+import {
+  ReconciledElements,
+  reconcileElements,
+} from "../collab/reconciliation";
 import * as Sentry from "@sentry/browser";
+
+export type SaveResult =
+  | { saved: true; reconciledElements: ReconciledElements | null }
+  | { saved: false; reconciledElements: null };
 
 export const encryptElements = async (
   elements: readonly ExcalidrawElement[],
@@ -193,12 +202,12 @@ const getSyncableElementsFromResponse = async (response: Response) => {
   return getSyncableElements(JSON.parse((await response.json()).data) || []);
 };
 
-// TODO (Jess): Consider adding reconciliation here, similar to firebase impl
 export const saveToHttpStorage = async (
   portal: Portal,
   elements: readonly ExcalidrawElement[],
   tokenService: TokenService,
-) => {
+  appState: AppState,
+): Promise<SaveResult> => {
   const { roomId, roomKey, socket } = portal;
   if (
     // if no room exists, consider the room saved because there's nothing we can
@@ -208,13 +217,11 @@ export const saveToHttpStorage = async (
     !socket ||
     isSavedToHttpStorage(portal, elements)
   ) {
-    return true;
+    return { saved: true, reconciledElements: null };
   }
   const token = await tokenService.getToken();
 
   console.info("[draw] Saving to HTTP storage", roomId, roomKey);
-
-  const sceneVersion = getSceneVersion(elements);
 
   const getResponse = await fetch(`${HTTP_STORAGE_BACKEND_URL}/drawing-data`, {
     method: "POST",
@@ -229,19 +236,29 @@ export const saveToHttpStorage = async (
   });
 
   if (!getResponse.ok && getResponse.status !== 404) {
-    return false;
+    return { saved: false, reconciledElements: null };
   }
+
+  // Determine what to write: reconciled (if remote exists) or local-only
+  let elementsToWrite: readonly ExcalidrawElement[] = elements;
+  let reconciledElements: ReconciledElements | null = null;
 
   if (getResponse.ok) {
     const existingElements = await getSyncableElementsFromResponse(getResponse);
 
-    if (existingElements && getSceneVersion(existingElements) >= sceneVersion) {
-      console.info(
-        "[draw] Scene is already saved",
-        sceneVersion,
-        getSceneVersion(existingElements),
+    if (existingElements && existingElements.length > 0) {
+      reconciledElements = reconcileElements(
+        elements,
+        existingElements,
+        appState,
       );
-      return false;
+      elementsToWrite = reconciledElements;
+
+      // If reconciled version matches cache, nothing new to save
+      const reconciledVersion = getSceneVersion(reconciledElements);
+      if (httpStorageSceneVersionCache.get(socket) === reconciledVersion) {
+        return { saved: true, reconciledElements };
+      }
     }
   }
 
@@ -259,15 +276,15 @@ export const saveToHttpStorage = async (
     body: new URLSearchParams({
       roomId,
       roomKey,
-      data: JSON.stringify(elements),
+      data: JSON.stringify(elementsToWrite),
     }),
   });
 
   if (putResponse.ok) {
-    httpStorageSceneVersionCache.set(socket, sceneVersion);
-    return true;
+    httpStorageSceneVersionCache.set(socket, getSceneVersion(elementsToWrite));
+    return { saved: true, reconciledElements };
   }
-  return false;
+  return { saved: false, reconciledElements: null };
 };
 
 // TODO (Jess): might need to look at getSceneVersion... new is using elements

--- a/excalidraw-app/data/httpStorage.ts
+++ b/excalidraw-app/data/httpStorage.ts
@@ -253,13 +253,14 @@ export const saveToHttpStorage = async (
         appState,
       );
       elementsToWrite = reconciledElements;
-
-      // If reconciled version matches cache, nothing new to save
-      const reconciledVersion = getSceneVersion(reconciledElements);
-      if (httpStorageSceneVersionCache.get(socket) === reconciledVersion) {
-        return { saved: true, reconciledElements };
-      }
     }
+  }
+
+  const versionToWrite = getSceneVersion(elementsToWrite);
+
+  // If reconciled version matches cache, nothing new to save
+  if (httpStorageSceneVersionCache.get(socket) === versionToWrite) {
+    return { saved: true, reconciledElements };
   }
 
   console.info("[draw] Saving drawing data...");
@@ -281,7 +282,7 @@ export const saveToHttpStorage = async (
   });
 
   if (putResponse.ok) {
-    httpStorageSceneVersionCache.set(socket, getSceneVersion(elementsToWrite));
+    httpStorageSceneVersionCache.set(socket, versionToWrite);
     return { saved: true, reconciledElements };
   }
   return { saved: false, reconciledElements: null };

--- a/excalidraw-app/tests/httpStorage.test.ts
+++ b/excalidraw-app/tests/httpStorage.test.ts
@@ -4,13 +4,13 @@ import { AppState } from "../../packages/excalidraw/types";
 import { saveToHttpStorage, TokenService } from "../data/httpStorage";
 import Portal from "../collab/Portal";
 
-// Stub import.meta.env
 vi.stubEnv("VITE_APP_HTTP_SERVER_URL", "http://test-backend/api");
 
+let nonceCounter = 0;
 const createElement = (
   id: string,
   version: number,
-  versionNonce: number = Math.floor(Math.random() * 1000),
+  versionNonce: number = ++nonceCounter,
 ): ExcalidrawElement =>
   ({
     id,
@@ -24,7 +24,7 @@ const createElement = (
 
 const makePortal = (): Portal => {
   const portal = new Portal(null as any);
-  // Use a fresh socket object per call so the WeakMap cache doesn't persist
+  // Fresh socket per call so the WeakMap version cache doesn't persist
   portal.socket = { id: Math.random().toString() } as any;
   portal.roomId = "test-room";
   portal.roomKey = "test-key";
@@ -54,9 +54,16 @@ const jsonResponse = (data: any, status = 200) =>
     headers: { "Content-Type": "application/json" },
   });
 
+const getWrittenElements = (fetchMock: ReturnType<typeof vi.fn>) => {
+  const postCall = fetchMock.mock.calls[1];
+  const postBody = postCall[1].body as URLSearchParams;
+  return JSON.parse(postBody.get("data")!);
+};
+
 describe("saveToHttpStorage", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    nonceCounter = 0;
   });
 
   it("saves local elements when no remote data exists (404)", async () => {
@@ -64,9 +71,7 @@ describe("saveToHttpStorage", () => {
     const elements = [createElement("A", 1), createElement("B", 1)];
 
     const fetchMock = mockFetchResponses([
-      // GET returns 404 (no existing data)
       new Response(null, { status: 404 }),
-      // POST succeeds
       new Response(null, { status: 200 }),
     ]);
 
@@ -80,10 +85,7 @@ describe("saveToHttpStorage", () => {
     expect(result.saved).toBe(true);
     expect(result.reconciledElements).toBeNull();
 
-    // Verify the POST body contains the local elements
-    const postCall = fetchMock.mock.calls[1];
-    const postBody = postCall[1].body as URLSearchParams;
-    const writtenElements = JSON.parse(postBody.get("data")!);
+    const writtenElements = getWrittenElements(fetchMock);
     expect(writtenElements).toHaveLength(2);
     expect(writtenElements[0].id).toBe("A");
     expect(writtenElements[1].id).toBe("B");
@@ -95,9 +97,7 @@ describe("saveToHttpStorage", () => {
     const remoteElements = [createElement("A", 1), createElement("C", 1)];
 
     const fetchMock = mockFetchResponses([
-      // GET returns existing remote elements
       jsonResponse({ data: JSON.stringify(remoteElements) }),
-      // POST succeeds
       new Response(null, { status: 200 }),
     ]);
 
@@ -111,70 +111,41 @@ describe("saveToHttpStorage", () => {
     expect(result.saved).toBe(true);
     expect(result.reconciledElements).not.toBeNull();
 
-    // Verify the POST body contains reconciled elements (all three)
-    const postCall = fetchMock.mock.calls[1];
-    const postBody = postCall[1].body as URLSearchParams;
-    const writtenElements = JSON.parse(postBody.get("data")!);
-    const writtenIds = writtenElements.map((e: any) => e.id);
+    const writtenIds = getWrittenElements(fetchMock).map((e: any) => e.id);
     expect(writtenIds).toContain("A");
     expect(writtenIds).toContain("B");
     expect(writtenIds).toContain("C");
   });
 
-  it("keeps local version when local is newer", async () => {
-    const portal = makePortal();
-    const localA = createElement("A", 5, 100);
-    const remoteA = createElement("A", 2, 200);
+  it.each([
+    ["local is newer", 5, 2, 5],
+    ["remote is newer", 1, 5, 5],
+  ])(
+    "resolves version conflict when %s",
+    async (_label, localVersion, remoteVersion, expectedVersion) => {
+      const portal = makePortal();
+      const localA = createElement("A", localVersion, 100);
+      const remoteA = createElement("A", remoteVersion, 200);
 
-    const fetchMock = mockFetchResponses([
-      jsonResponse({ data: JSON.stringify([remoteA]) }),
-      new Response(null, { status: 200 }),
-    ]);
+      const fetchMock = mockFetchResponses([
+        jsonResponse({ data: JSON.stringify([remoteA]) }),
+        new Response(null, { status: 200 }),
+      ]);
 
-    const result = await saveToHttpStorage(
-      portal,
-      [localA],
-      makeTokenService(),
-      emptyAppState,
-    );
+      const result = await saveToHttpStorage(
+        portal,
+        [localA],
+        makeTokenService(),
+        emptyAppState,
+      );
 
-    expect(result.saved).toBe(true);
-    expect(result.reconciledElements).not.toBeNull();
+      expect(result.saved).toBe(true);
 
-    const postCall = fetchMock.mock.calls[1];
-    const postBody = postCall[1].body as URLSearchParams;
-    const writtenElements = JSON.parse(postBody.get("data")!);
-    // Local A (version 5) should win over remote A (version 2)
-    expect(writtenElements[0].id).toBe("A");
-    expect(writtenElements[0].version).toBe(5);
-  });
-
-  it("takes remote version when remote is newer", async () => {
-    const portal = makePortal();
-    const localA = createElement("A", 1, 100);
-    const remoteA = createElement("A", 5, 200);
-
-    const fetchMock = mockFetchResponses([
-      jsonResponse({ data: JSON.stringify([remoteA]) }),
-      new Response(null, { status: 200 }),
-    ]);
-
-    const result = await saveToHttpStorage(
-      portal,
-      [localA],
-      makeTokenService(),
-      emptyAppState,
-    );
-
-    expect(result.saved).toBe(true);
-
-    const postCall = fetchMock.mock.calls[1];
-    const postBody = postCall[1].body as URLSearchParams;
-    const writtenElements = JSON.parse(postBody.get("data")!);
-    // Remote A (version 5) should win over local A (version 1)
-    expect(writtenElements[0].id).toBe("A");
-    expect(writtenElements[0].version).toBe(5);
-  });
+      const writtenElements = getWrittenElements(fetchMock);
+      expect(writtenElements[0].id).toBe("A");
+      expect(writtenElements[0].version).toBe(expectedVersion);
+    },
+  );
 
   it("returns saved:false when GET fails with non-404 status", async () => {
     const portal = makePortal();
@@ -211,7 +182,6 @@ describe("saveToHttpStorage", () => {
 
   it("skips save when no room exists", async () => {
     const portal = new Portal(null as any);
-    // roomId, roomKey, socket all null
 
     const fetchMock = mockFetchResponses([]);
 

--- a/excalidraw-app/tests/httpStorage.test.ts
+++ b/excalidraw-app/tests/httpStorage.test.ts
@@ -20,7 +20,7 @@ const createElement = (
     updated: Date.now(),
     width: 100,
     height: 100,
-  }) as any as ExcalidrawElement;
+  } as any as ExcalidrawElement);
 
 const makePortal = (): Portal => {
   const portal = new Portal(null as any);

--- a/excalidraw-app/tests/httpStorage.test.ts
+++ b/excalidraw-app/tests/httpStorage.test.ts
@@ -1,0 +1,228 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { ExcalidrawElement } from "../../packages/excalidraw/element/types";
+import { AppState } from "../../packages/excalidraw/types";
+import { saveToHttpStorage, TokenService } from "../data/httpStorage";
+import Portal from "../collab/Portal";
+
+// Stub import.meta.env
+vi.stubEnv("VITE_APP_HTTP_SERVER_URL", "http://test-backend/api");
+
+const createElement = (
+  id: string,
+  version: number,
+  versionNonce: number = Math.floor(Math.random() * 1000),
+): ExcalidrawElement =>
+  ({
+    id,
+    version,
+    versionNonce,
+    isDeleted: false,
+    updated: Date.now(),
+    width: 100,
+    height: 100,
+  }) as any as ExcalidrawElement;
+
+const makePortal = (): Portal => {
+  const portal = new Portal(null as any);
+  // Use a fresh socket object per call so the WeakMap cache doesn't persist
+  portal.socket = { id: Math.random().toString() } as any;
+  portal.roomId = "test-room";
+  portal.roomKey = "test-key";
+  return portal;
+};
+
+const makeTokenService = (): TokenService => {
+  const ts = new TokenService();
+  vi.spyOn(ts, "getToken").mockResolvedValue("test-token");
+  return ts;
+};
+
+const emptyAppState = {} as AppState;
+
+const mockFetchResponses = (responses: Response[]) => {
+  const fetchMock = vi.fn();
+  for (const response of responses) {
+    fetchMock.mockResolvedValueOnce(response);
+  }
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+};
+
+const jsonResponse = (data: any, status = 200) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("saveToHttpStorage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("saves local elements when no remote data exists (404)", async () => {
+    const portal = makePortal();
+    const elements = [createElement("A", 1), createElement("B", 1)];
+
+    const fetchMock = mockFetchResponses([
+      // GET returns 404 (no existing data)
+      new Response(null, { status: 404 }),
+      // POST succeeds
+      new Response(null, { status: 200 }),
+    ]);
+
+    const result = await saveToHttpStorage(
+      portal,
+      elements,
+      makeTokenService(),
+      emptyAppState,
+    );
+
+    expect(result.saved).toBe(true);
+    expect(result.reconciledElements).toBeNull();
+
+    // Verify the POST body contains the local elements
+    const postCall = fetchMock.mock.calls[1];
+    const postBody = postCall[1].body as URLSearchParams;
+    const writtenElements = JSON.parse(postBody.get("data")!);
+    expect(writtenElements).toHaveLength(2);
+    expect(writtenElements[0].id).toBe("A");
+    expect(writtenElements[1].id).toBe("B");
+  });
+
+  it("reconciles when remote data exists with different elements", async () => {
+    const portal = makePortal();
+    const localElements = [createElement("A", 2), createElement("B", 1)];
+    const remoteElements = [createElement("A", 1), createElement("C", 1)];
+
+    const fetchMock = mockFetchResponses([
+      // GET returns existing remote elements
+      jsonResponse({ data: JSON.stringify(remoteElements) }),
+      // POST succeeds
+      new Response(null, { status: 200 }),
+    ]);
+
+    const result = await saveToHttpStorage(
+      portal,
+      localElements,
+      makeTokenService(),
+      emptyAppState,
+    );
+
+    expect(result.saved).toBe(true);
+    expect(result.reconciledElements).not.toBeNull();
+
+    // Verify the POST body contains reconciled elements (all three)
+    const postCall = fetchMock.mock.calls[1];
+    const postBody = postCall[1].body as URLSearchParams;
+    const writtenElements = JSON.parse(postBody.get("data")!);
+    const writtenIds = writtenElements.map((e: any) => e.id);
+    expect(writtenIds).toContain("A");
+    expect(writtenIds).toContain("B");
+    expect(writtenIds).toContain("C");
+  });
+
+  it("keeps local version when local is newer", async () => {
+    const portal = makePortal();
+    const localA = createElement("A", 5, 100);
+    const remoteA = createElement("A", 2, 200);
+
+    const fetchMock = mockFetchResponses([
+      jsonResponse({ data: JSON.stringify([remoteA]) }),
+      new Response(null, { status: 200 }),
+    ]);
+
+    const result = await saveToHttpStorage(
+      portal,
+      [localA],
+      makeTokenService(),
+      emptyAppState,
+    );
+
+    expect(result.saved).toBe(true);
+    expect(result.reconciledElements).not.toBeNull();
+
+    const postCall = fetchMock.mock.calls[1];
+    const postBody = postCall[1].body as URLSearchParams;
+    const writtenElements = JSON.parse(postBody.get("data")!);
+    // Local A (version 5) should win over remote A (version 2)
+    expect(writtenElements[0].id).toBe("A");
+    expect(writtenElements[0].version).toBe(5);
+  });
+
+  it("takes remote version when remote is newer", async () => {
+    const portal = makePortal();
+    const localA = createElement("A", 1, 100);
+    const remoteA = createElement("A", 5, 200);
+
+    const fetchMock = mockFetchResponses([
+      jsonResponse({ data: JSON.stringify([remoteA]) }),
+      new Response(null, { status: 200 }),
+    ]);
+
+    const result = await saveToHttpStorage(
+      portal,
+      [localA],
+      makeTokenService(),
+      emptyAppState,
+    );
+
+    expect(result.saved).toBe(true);
+
+    const postCall = fetchMock.mock.calls[1];
+    const postBody = postCall[1].body as URLSearchParams;
+    const writtenElements = JSON.parse(postBody.get("data")!);
+    // Remote A (version 5) should win over local A (version 1)
+    expect(writtenElements[0].id).toBe("A");
+    expect(writtenElements[0].version).toBe(5);
+  });
+
+  it("returns saved:false when GET fails with non-404 status", async () => {
+    const portal = makePortal();
+
+    mockFetchResponses([new Response(null, { status: 500 })]);
+
+    const result = await saveToHttpStorage(
+      portal,
+      [createElement("A", 1)],
+      makeTokenService(),
+      emptyAppState,
+    );
+
+    expect(result).toEqual({ saved: false, reconciledElements: null });
+  });
+
+  it("returns saved:false when POST fails", async () => {
+    const portal = makePortal();
+
+    mockFetchResponses([
+      new Response(null, { status: 404 }),
+      new Response(null, { status: 500 }),
+    ]);
+
+    const result = await saveToHttpStorage(
+      portal,
+      [createElement("A", 1)],
+      makeTokenService(),
+      emptyAppState,
+    );
+
+    expect(result).toEqual({ saved: false, reconciledElements: null });
+  });
+
+  it("skips save when no room exists", async () => {
+    const portal = new Portal(null as any);
+    // roomId, roomKey, socket all null
+
+    const fetchMock = mockFetchResponses([]);
+
+    const result = await saveToHttpStorage(
+      portal,
+      [createElement("A", 1)],
+      makeTokenService(),
+      emptyAppState,
+    );
+
+    expect(result).toEqual({ saved: true, reconciledElements: null });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds element reconciliation to the HTTP storage save path, closing a data consistency gap from the Firebase → HTTP migration
- When saving, the function now reads the server state, merges local + remote elements via `reconcileElements`, and writes the merged result — preventing silent data loss during concurrent edits
- Renames stale Firebase method names (`saveCollabRoomToFirebase` → `saveCollabRoomToHttpStorage`, `queueSaveToFirebase` → `queueSaveToHttpStorage`)
- Returns a typed `SaveResult` instead of a bare boolean, so the caller can apply reconciled elements to the local scene
- Adds 7 unit tests covering: no remote data (404), reconciliation with divergent elements, version conflict resolution (local wins / remote wins), GET failure, POST failure, and no-room early exit

## Test plan

- [x] All 10 existing + new tests pass (`yarn test:app --watch=false`)
- [x] TypeScript type check passes (`yarn test:typecheck`)
- [x] Snyk code scan clean on both modified files
- [x] Manual test: open two browser tabs in a collab room, edit in both, verify HTTP storage contains merged state
- [x] Manual test: disconnect one tab, make edits in both, reconnect — verify no data loss on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213840841325135