### PR TITLE
fix: make HTTP storage saves resilient to transient failures

### DIFF
--- a/excalidraw-app/collab/Collab.tsx
+++ b/excalidraw-app/collab/Collab.tsx
@@ -286,40 +286,56 @@ class Collab extends PureComponent<CollabProps, CollabState> {
     }
   });
 
+  private consecutiveSaveFailures = 0;
+  private static readonly MAX_SAVE_RETRIES = 3;
+
   saveCollabRoomToHttpStorage = async (
     syncableElements: readonly SyncableExcalidrawElement[],
   ) => {
-    try {
-      const savedData = await saveToHttpStorage(
-        this.portal,
-        syncableElements,
-        this.tokenService,
-        this.excalidrawAPI.getAppState(),
-      );
+    const savedData = await saveToHttpStorage(
+      this.portal,
+      syncableElements,
+      this.tokenService,
+      this.excalidrawAPI.getAppState(),
+    );
 
-      if (
-        this.isCollaborating() &&
-        savedData.saved &&
-        savedData.reconciledElements
-      ) {
+    if (savedData.saved) {
+      if (this.consecutiveSaveFailures > 0) {
+        this.consecutiveSaveFailures = 0;
+        this.setState({ errorMessage: null });
+      }
+      if (this.isCollaborating() && savedData.reconciledElements) {
         this.setLastBroadcastedOrReceivedSceneVersion(
           getSceneVersion(savedData.reconciledElements),
         );
         this.handleRemoteSceneUpdate(savedData.reconciledElements);
       }
-    } catch (error: any) {
-      const sizeExceeded = /is longer than.*?bytes/.test(error.message);
+      return;
+    }
+
+    // Size exceeded is not retryable — show error immediately
+    if (savedData.reason === "size_exceeded") {
       this.setState({
-        errorMessage: sizeExceeded
-          ? t("errors.collabSaveFailed_sizeExceeded")
-          : t("errors.collabSaveFailed"),
+        errorMessage: t("errors.collabSaveFailed_sizeExceeded"),
       });
-      console.error(error);
-      if (!sizeExceeded) {
-        setTimeout(() => {
-          window.location.reload();
-        }, 3000);
-      }
+      return;
+    }
+
+    // Other failures — let the throttle retry on the next tick
+    this.consecutiveSaveFailures++;
+    console.warn(
+      `[draw] Save failed (attempt ${this.consecutiveSaveFailures}):`,
+      savedData.reason,
+    );
+
+    if (this.consecutiveSaveFailures >= Collab.MAX_SAVE_RETRIES) {
+      this.setState({
+        errorMessage: t("errors.collabSaveFailed"),
+      });
+      console.error(
+        `[draw] Save failed after ${Collab.MAX_SAVE_RETRIES} consecutive attempts, reason:`,
+        savedData.reason,
+      );
     }
   };
 
@@ -327,6 +343,7 @@ class Collab extends PureComponent<CollabProps, CollabState> {
     this.queueBroadcastAllElements.cancel();
     this.queueSaveToHttpStorage.cancel();
     this.loadImageFiles.cancel();
+    this.consecutiveSaveFailures = 0;
 
     this.saveCollabRoomToHttpStorage(
       getSyncableElements(

--- a/excalidraw-app/data/httpStorage.ts
+++ b/excalidraw-app/data/httpStorage.ts
@@ -23,9 +23,18 @@ import {
 } from "../collab/reconciliation";
 import * as Sentry from "@sentry/browser";
 
+export type SaveFailureReason =
+  | "token_error"
+  | "network_error"
+  | "auth_error"
+  | "get_failed"
+  | "parse_error"
+  | "size_exceeded"
+  | "post_failed";
+
 export type SaveResult =
   | { saved: true; reconciledElements: ReconciledElements | null }
-  | { saved: false; reconciledElements: null };
+  | { saved: false; reconciledElements: null; reason: SaveFailureReason };
 
 export const encryptElements = async (
   elements: readonly ExcalidrawElement[],
@@ -219,24 +228,40 @@ export const saveToHttpStorage = async (
   ) {
     return { saved: true, reconciledElements: null };
   }
-  const token = await tokenService.getToken();
+  let token: string;
+  try {
+    token = await tokenService.getToken();
+  } catch (error) {
+    console.warn("[draw] Token fetch failed:", error);
+    return { saved: false, reconciledElements: null, reason: "token_error" };
+  }
 
   console.info("[draw] Saving to HTTP storage", roomId, roomKey);
 
-  const getResponse = await fetch(`${HTTP_STORAGE_BACKEND_URL}/drawing-data`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: new URLSearchParams({
-      roomId,
-      roomKey,
-    }),
-  });
+  let getResponse: Response;
+  try {
+    getResponse = await fetch(`${HTTP_STORAGE_BACKEND_URL}/drawing-data`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        roomId,
+        roomKey,
+      }),
+    });
+  } catch (error) {
+    console.warn("[draw] Failed to fetch existing drawing data:", error);
+    return { saved: false, reconciledElements: null, reason: "network_error" };
+  }
 
   if (!getResponse.ok && getResponse.status !== 404) {
-    return { saved: false, reconciledElements: null };
+    if (getResponse.status === 401 || getResponse.status === 403) {
+      tokenService.clearToken();
+      return { saved: false, reconciledElements: null, reason: "auth_error" };
+    }
+    return { saved: false, reconciledElements: null, reason: "get_failed" };
   }
 
   // Determine what to write: reconciled (if remote exists) or local-only
@@ -244,7 +269,13 @@ export const saveToHttpStorage = async (
   let reconciledElements: ReconciledElements | null = null;
 
   if (getResponse.ok) {
-    const existingElements = await getSyncableElementsFromResponse(getResponse);
+    let existingElements;
+    try {
+      existingElements = await getSyncableElementsFromResponse(getResponse);
+    } catch (error) {
+      console.warn("[draw] Failed to parse existing drawing data:", error);
+      return { saved: false, reconciledElements: null, reason: "parse_error" };
+    }
 
     if (existingElements && existingElements.length > 0) {
       reconciledElements = reconcileElements(
@@ -265,27 +296,37 @@ export const saveToHttpStorage = async (
 
   console.info("[draw] Saving drawing data...");
 
-  const putHeaders: HeadersInit = {
-    "Content-Type": "application/x-www-form-urlencoded",
-  };
-
-  putHeaders.Authorization = `Bearer ${token}`;
-
-  const putResponse = await fetch(`${HTTP_STORAGE_BACKEND_URL}/drawing-data`, {
-    method: "POST",
-    headers: putHeaders,
-    body: new URLSearchParams({
-      roomId,
-      roomKey,
-      data: JSON.stringify(elementsToWrite),
-    }),
-  });
+  let putResponse: Response;
+  try {
+    putResponse = await fetch(`${HTTP_STORAGE_BACKEND_URL}/drawing-data`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        roomId,
+        roomKey,
+        data: JSON.stringify(elementsToWrite),
+      }),
+    });
+  } catch (error) {
+    console.warn("[draw] Failed to save drawing data:", error);
+    return { saved: false, reconciledElements: null, reason: "network_error" };
+  }
 
   if (putResponse.ok) {
     httpStorageSceneVersionCache.set(socket, versionToWrite);
     return { saved: true, reconciledElements };
   }
-  return { saved: false, reconciledElements: null };
+  if (putResponse.status === 401 || putResponse.status === 403) {
+    tokenService.clearToken();
+    return { saved: false, reconciledElements: null, reason: "auth_error" };
+  }
+  if (putResponse.status === 413) {
+    return { saved: false, reconciledElements: null, reason: "size_exceeded" };
+  }
+  return { saved: false, reconciledElements: null, reason: "post_failed" };
 };
 
 // TODO (Jess): might need to look at getSceneVersion... new is using elements

--- a/excalidraw-app/tests/httpStorage.test.ts
+++ b/excalidraw-app/tests/httpStorage.test.ts
@@ -37,6 +37,12 @@ const makeTokenService = (): TokenService => {
   return ts;
 };
 
+const makeFailingTokenService = (error: string): TokenService => {
+  const ts = new TokenService();
+  vi.spyOn(ts, "getToken").mockRejectedValue(new Error(error));
+  return ts;
+};
+
 const emptyAppState = {} as AppState;
 
 const mockFetchResponses = (responses: Response[]) => {
@@ -147,7 +153,7 @@ describe("saveToHttpStorage", () => {
     },
   );
 
-  it("returns saved:false when GET fails with non-404 status", async () => {
+  it("returns saved:false with reason when GET fails", async () => {
     const portal = makePortal();
 
     mockFetchResponses([new Response(null, { status: 500 })]);
@@ -159,10 +165,14 @@ describe("saveToHttpStorage", () => {
       emptyAppState,
     );
 
-    expect(result).toEqual({ saved: false, reconciledElements: null });
+    expect(result.saved).toBe(false);
+    expect(result.reconciledElements).toBeNull();
+    if (!result.saved) {
+      expect(result.reason).toBe("get_failed");
+    }
   });
 
-  it("returns saved:false when POST fails", async () => {
+  it("returns saved:false with reason when POST fails", async () => {
     const portal = makePortal();
 
     mockFetchResponses([
@@ -177,7 +187,10 @@ describe("saveToHttpStorage", () => {
       emptyAppState,
     );
 
-    expect(result).toEqual({ saved: false, reconciledElements: null });
+    expect(result.saved).toBe(false);
+    if (!result.saved) {
+      expect(result.reason).toBe("post_failed");
+    }
   });
 
   it("skips save when no room exists", async () => {
@@ -194,5 +207,134 @@ describe("saveToHttpStorage", () => {
 
     expect(result).toEqual({ saved: true, reconciledElements: null });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns saved:false on token service failure (does not throw)", async () => {
+    const portal = makePortal();
+
+    mockFetchResponses([]);
+
+    const result = await saveToHttpStorage(
+      portal,
+      [createElement("A", 1)],
+      makeFailingTokenService("Request timeout"),
+      emptyAppState,
+    );
+
+    expect(result.saved).toBe(false);
+    if (!result.saved) {
+      expect(result.reason).toBe("token_error");
+    }
+  });
+
+  it("returns saved:false on network error during GET (does not throw)", async () => {
+    const portal = makePortal();
+
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await saveToHttpStorage(
+      portal,
+      [createElement("A", 1)],
+      makeTokenService(),
+      emptyAppState,
+    );
+
+    expect(result.saved).toBe(false);
+    if (!result.saved) {
+      expect(result.reason).toBe("network_error");
+    }
+  });
+
+  it("returns saved:false on network error during POST (does not throw)", async () => {
+    const portal = makePortal();
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await saveToHttpStorage(
+      portal,
+      [createElement("A", 1)],
+      makeTokenService(),
+      emptyAppState,
+    );
+
+    expect(result.saved).toBe(false);
+    if (!result.saved) {
+      expect(result.reason).toBe("network_error");
+    }
+  });
+
+  it("returns saved:false on malformed response JSON (does not throw)", async () => {
+    const portal = makePortal();
+
+    mockFetchResponses([
+      new Response("not json", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ]);
+
+    const result = await saveToHttpStorage(
+      portal,
+      [createElement("A", 1)],
+      makeTokenService(),
+      emptyAppState,
+    );
+
+    expect(result.saved).toBe(false);
+    if (!result.saved) {
+      expect(result.reason).toBe("parse_error");
+    }
+  });
+
+  it.each([401, 403])(
+    "returns auth_error and clears token on %i response",
+    async (status) => {
+      const portal = makePortal();
+      const tokenService = makeTokenService();
+      const clearSpy = vi.spyOn(tokenService, "clearToken");
+
+      mockFetchResponses([new Response(null, { status })]);
+
+      const result = await saveToHttpStorage(
+        portal,
+        [createElement("A", 1)],
+        tokenService,
+        emptyAppState,
+      );
+
+      expect(result.saved).toBe(false);
+      if (!result.saved) {
+        expect(result.reason).toBe("auth_error");
+      }
+      expect(clearSpy).toHaveBeenCalled();
+    },
+  );
+
+  it("returns size_exceeded on 413 response from POST", async () => {
+    const portal = makePortal();
+
+    mockFetchResponses([
+      new Response(null, { status: 404 }),
+      new Response(null, { status: 413 }),
+    ]);
+
+    const result = await saveToHttpStorage(
+      portal,
+      [createElement("A", 1)],
+      makeTokenService(),
+      emptyAppState,
+    );
+
+    expect(result.saved).toBe(false);
+    if (!result.saved) {
+      expect(result.reason).toBe("size_exceeded");
+    }
   });
 });


### PR DESCRIPTION
> **Stacked on #112** (`feat/reconcile-http-storage-saves`) — review that PR first.

## Summary

- `saveToHttpStorage` now **never throws** — all failure paths (token timeout, network error, auth failure, parse error, server error) return a typed `SaveResult` with a `SaveFailureReason` string union
- The caller tracks consecutive failures and only shows the error dialog after 3 consecutive failed saves (was: immediate error + forced page reload on any exception)
- Transient failures retry silently via the existing 1000ms throttle; successful saves clear the error
- 401/403 responses clear the cached token so the next retry fetches a fresh one from the parent frame
- 413 (payload too large) shows a specific error immediately without retrying
- No more forced page reloads — eliminates loss of undo history, zoom/scroll state, and socket connections
- Failure counter is reset in `stopCollaboration` to prevent stale state across sessions

## Test plan

- [x] 15 tests pass including 7 new tests for: token error, network error on GET/POST, malformed JSON, 401/403 auth error with token clear, 413 size exceeded
- [x] TypeScript type check passes
- [x] ESLint passes (0 warnings)
- [x] Snyk code scan clean
- [ ] Manual: block postMessage in devtools to simulate token timeout → verify error appears after 3 failures, no page reload, saves resume when unblocked
- [ ] Manual: throttle network to simulate fetch failures → verify silent retries, error after 3 failures, recovery on reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213841145835182