### PR TITLE
chore: clean up resolved TODO comments, fix lastRetrieved

### DIFF
--- a/excalidraw-app/collab/Collab.tsx
+++ b/excalidraw-app/collab/Collab.tsx
@@ -161,7 +161,6 @@ class Collab extends PureComponent<CollabProps, CollabState> {
           throw new AbortError();
         }
 
-        // TODO (Jess): Reconsider encoding files for upload
         return saveFilesToHttpStorage({
           files: await encodeFilesForUpload({
             files: addedFiles,

--- a/excalidraw-app/data/httpStorage.ts
+++ b/excalidraw-app/data/httpStorage.ts
@@ -329,8 +329,6 @@ export const saveToHttpStorage = async (
   return { saved: false, reconciledElements: null, reason: "post_failed" };
 };
 
-// TODO (Jess): might need to look at getSceneVersion... new is using elements
-// as a whole, not just version number for the version cache
 export const loadFromHttpStorage = async (
   roomId: string,
   roomKey: string,
@@ -451,8 +449,7 @@ export const loadFilesFromHttpStorage = async (
             id,
             dataURL,
             created: metadata?.created || Date.now(),
-            // TODO (Jess): consider adding:
-            // lastRetrieved: metadata?.created || Date.now(),
+            lastRetrieved: Date.now(),
           });
         } else if (response.status === 403) {
           // Note that we don't consider this an "erroredFile" because we still want

--- a/excalidraw-app/data/index.ts
+++ b/excalidraw-app/data/index.ts
@@ -123,11 +123,6 @@ export const isCollaborationLink = (link: string) => {
 export const getCollaborationLinkData = (link: string) => {
   const hash = new URL(link).hash;
   const match = hash.match(RE_COLLAB_LINK);
-  // TODO (Jess): Add this back in if we are using encrypted room keys
-  // if (match && match[2].length !== 22) {
-  //   window.alert(t("alerts.invalidEncryptionKey"));
-  //   return null;
-  // }
   return match ? { roomId: match[1], roomKey: match[2] } : null;
 };
 

--- a/packages/excalidraw/data/encryption.ts
+++ b/packages/excalidraw/data/encryption.ts
@@ -45,7 +45,7 @@ export const getCryptoKey = (key: string, usage: KeyUsage) =>
     [usage],
   );
 
-// TODO (Jess): Reconsider if we want to use this
+// Backend handles auth/transport security
 export const encryptData = async (
   key: string | CryptoKey,
   data: Uint8Array | ArrayBuffer | Blob | File | string,


### PR DESCRIPTION
> **Stacked on #114** (`fix/resilient-http-storage-saves`) ← **#112** (`feat/reconcile-http-storage-saves`)

## Summary

Investigated all 8 `TODO` comments left during the Firebase → HTTP storage migration. Resolved 5, deferred 3.

**Fixed:**
- Set `lastRetrieved: Date.now()` when loading files from HTTP storage — enables garbage collection of unused files (was commented out with wrong value)

**Removed (resolved):**
- Scene version caching TODO — implementation is correct, no mismatch
- File encoding TODO — encoding (compress + metadata) is necessary for the backend format
- `encryptData` TODO — encryption was intentionally disabled; replaced with explanatory comment
- Encryption key validation TODO + dead code — validation logic was wrong for current key format

**Deferred:**
- `exportToBackend` is fully stubbed — re-enabling shareable link export requires a backend endpoint
- Two TODOs inside the stubbed export body are moot until the feature is implemented

## Test plan

- [x] All 683 tests pass
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213841145835187