### PR TITLE
fix: bump lodash-es to >=4.18.1 to resolve CVE-2026-4800

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "cross-spawn": "7.0.6",
     "immutable": "4.3.8",
     "socket.io-parser": "4.2.6",
-    "picomatch": "2.3.2"
+    "picomatch": "2.3.2",
+    "lodash-es": ">=4.18.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7578,10 +7578,10 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+lodash-es@>=4.18.1, lodash-es@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash.debounce@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
## Summary

Resolves high-severity **Arbitrary Code Injection** vulnerability (CWE-94) in `lodash-es@4.17.21`, flagged by Snyk.

- **CVE**: CVE-2026-4800
- **Snyk**: SNYK-JS-LODASHES-15869627
- **Fixed in**: lodash-es >= 4.18.1
- **Introduced via**: transitive dep — `mermaid` → `@excalidraw/mermaid-to-excalidraw` → `lodash-es`

## Fix

Added `"lodash-es": ">=4.18.1"` to the `resolutions` block in the root `package.json`, matching the existing pattern used for other security-driven pins (`@babel/traverse`, `ws`, `braces`, `cross-spawn`, etc.). Yarn lockfile regenerated: `lodash-es` bumped from 4.17.21 → 4.18.1.