### PR TITLE
fix: add yarn resolution for protobufjs ^7.5.5 (SNYK-JS-PROTOBUFJS-16094665)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "immutable": "4.3.8",
     "socket.io-parser": "4.2.6",
     "picomatch": "2.3.2",
-    "lodash-es": ">=4.18.1"
+    "lodash-es": ">=4.18.1",
+    "protobufjs": "^7.5.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8697,10 +8697,10 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-protobufjs@^7.3.0:
-  version "7.5.4"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.4.tgz#885d31fe9c4b37f25d1bb600da30b1c5b37d286a"
-  integrity sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==
+protobufjs@^7.3.0, protobufjs@^7.5.5:
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.5.tgz#b7089ca4410374c75150baf277353ef76db69f96"
+  integrity sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
## Summary
— Snyk advisory [SNYK-JS-PROTOBUFJS-16094665](https://security.snyk.io/vuln/SNYK-JS-PROTOBUFJS-16094665).

## Test plan
- [x] `yarn install` — lockfile updates cleanly, `protobufjs` resolves to `7.5.5`
- [x] `mcp__Snyk__snyk_sca_scan` at `high` threshold — 0 issues (was 1 critical)
- [x] `yarn test:typecheck` — clean
- [x] `yarn test:app --watch=false` — 669 tests pass across 62 files
- [x] CI green

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214120770667805