### PR TITLE
chore: ignore local agent config and the docs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ html
 examples/**/bundle.*
 CLAUDE.md 
 settings.local.json
+.compound-engineering/*.local.yaml
+docs/


### PR DESCRIPTION
## Description

Coding agents write working artifacts into `docs/` (plans, explainers, reviews) and per-developer config into `.compound-engineering/`. None of it is currently ignored, so it is one stray `git add -A` away from being committed. This ignores both so that can't happen by accident.

Two scoping notes:

- `docs/` is ignored wholesale, so a human-authored doc placed there would also be invisible to git. If we want checked-in project documentation later, it needs a different directory or an explicit negation.
- Under `.compound-engineering/`, only `*.local.yaml` is ignored — per-developer config — which leaves room for a shared `config.yaml` to be checked in if we ever want team-wide defaults.

Nothing under either path is tracked today, so no existing files are orphaned. Note this only prevents future commits; anything already committed on another branch would survive a merge.

## Tests to be performed

- [x] Pre-merge - `git check-ignore -v` confirms the rules match real paths (`.compound-engineering/config.local.yaml`, `docs/plans/…`, `docs/explainers/…`); `git ls-files` confirms nothing tracked under either path.
- [ ] Post-merge - none required; no build, runtime, or test surface is affected.

## Type of change

- Code refactor (repository housekeeping; no build, runtime, or test behavior changes)

## Testing Checklist

- [x] All pre-merge tests under "Tests" performed prior to merging.
- [ ] All security issues identified during the review process have been remediated.
